### PR TITLE
Fix: configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,18 @@ APIs and admin tasks for Littlepay.
 
 ```console
 $ littlepay -h
-usage: littlepay [-h] [-v] {config,switch} ...
+usage: littlepay [-h] [-v] [-c CONFIG_PATH] {config,switch} ...
 
 positional arguments:
   {config,switch}
-    config         Get or set configuration.
-    switch         Switch the active environment or participant.
+    config              Get or set configuration.
+    switch              Switch the active environment or participant.
 
 options:
-  -h, --help       show this help message and exit
-  -v, --version    show program's version number and exit
+  -h, --help            show this help message and exit
+  -v, --version         show program's version number and exit
+  -c CONFIG_PATH, --config CONFIG_PATH
+                        Path to a readable and writeable config file to use. File will be created if it does not exist.
 ```
 
 ## Install
@@ -60,9 +62,14 @@ envs:
     url: ""
 participants:
   cst:
-    audience: ""
-    client_id: ""
-    client_secret: ""
+    qa:
+      audience: ""
+      client_id: ""
+      client_secret: ""
+    prod:
+      audience: ""
+      client_id: ""
+      client_secret: ""
 ```
 
 There are two `envs` by default, the base API URL should be completed for each:
@@ -75,7 +82,13 @@ Add specifics for the `participants` you manage based on information received fr
 ### Use a different config file
 
 ```console
-littlepay config -c /path/to/new/config.yaml
+littlepay config /path/to/new/config.yaml
+```
+
+Or
+
+```
+littlepay --config /path/to/new/config.yaml
 ```
 
 The most recent config used is saved for next time.

--- a/littlepay/main.py
+++ b/littlepay/main.py
@@ -1,4 +1,4 @@
-import argparse
+from argparse import ArgumentParser
 import sys
 
 from littlepay import __version__ as version
@@ -9,7 +9,7 @@ from littlepay.config import CONFIG_TYPES, Config
 
 def main(argv=None):
     argv = argv if argv is not None else sys.argv[1:]
-    parser = argparse.ArgumentParser(prog="littlepay")
+    parser = ArgumentParser(prog="littlepay")
 
     # https://stackoverflow.com/a/8521644/812183
     parser.add_argument(
@@ -18,21 +18,25 @@ def main(argv=None):
         action="version",
         version=f"%(prog)s {version}",
     )
+    parser.add_argument(
+        "-c",
+        "--config",
+        dest="config_path",
+        help="Path to a readable and writeable config file to use. File will be created if it does not exist.",
+    )
 
     subparsers = parser.add_subparsers(dest="command")
 
-    def _subcmd(name, help) -> argparse.ArgumentParser:
+    def _subcmd(name, help) -> ArgumentParser:
         """Helper creates a new subcommand parser."""
         parser = subparsers.add_parser(name, help=help)
         return parser
 
     config_parser = _subcmd("config", help="Get or set configuration.")
     config_parser.add_argument(
-        "-c",
-        "--config",
+        "config_path",
+        nargs="?",
         default=Config.current_path(),
-        dest="config_path",
-        help="Path to a readable and writeable config file to use. File will be created if it does not exist.",
     )
 
     switch_parser = _subcmd("switch", help="Switch the active environment or participant.")
@@ -44,7 +48,7 @@ def main(argv=None):
 
     args = parser.parse_args(argv)
 
-    if args.command == "config":
+    if args.command == "config" or args.config_path:
         return configure(args.config_path)
     elif args.command == "switch":
         return switch(args.switch_type, args.switch_arg)

--- a/tests/test_littlepay.py
+++ b/tests/test_littlepay.py
@@ -1,6 +1,32 @@
+from pathlib import Path
 import subprocess
 
+import pytest
+
 from littlepay.commands import RESULT_FAILURE
+from littlepay.config import _get_current_path, _update_current_path
+from tests.conftest import CUSTOM_CONFIG_FILE
+
+
+@pytest.fixture(autouse=True)
+def custom_config_file() -> Path:
+    """Override fixture in conftest to temporarily use the CUSTOM_CONFIG_FILE as a "real" config file."""
+    default = _get_current_path()
+
+    custom = Path(CUSTOM_CONFIG_FILE)
+    custom.unlink(missing_ok=True)
+    _update_current_path(custom)
+
+    yield custom
+
+    custom.unlink(missing_ok=True)
+    _update_current_path(default)
+
+
+@pytest.fixture(autouse=True)
+def custom_current_file() -> Path:
+    """Override fixture in conftest to NOT return the test .current file, use the real one."""
+    return
 
 
 def test_littlepay(capfd):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,8 @@
+from pathlib import Path
 import pytest
 
 from littlepay.commands import RESULT_SUCCESS
-from littlepay.config import CONFIG_TYPES
+from littlepay.config import CONFIG_TYPES, Config
 from littlepay.main import main, __name__ as MODULE
 
 
@@ -15,18 +16,42 @@ def mock_commands_switch(mock_commands_switch):
     return mock_commands_switch(MODULE)
 
 
-def test_main_config(mock_commands_config):
-    result = main(argv=["config"])
-
-    assert result == RESULT_SUCCESS
-    mock_commands_config.assert_called_once()
-
-
 def test_main_default(mock_commands_config):
     result = main(argv=[])
 
     assert result == RESULT_SUCCESS
-    mock_commands_config.assert_called_once()
+    mock_commands_config.assert_called_once_with(Config().current_path())
+
+
+@pytest.mark.parametrize("config_flag", ["-c", "--config"])
+def test_main_config_flag(custom_config_file: Path, mock_commands_config, config_flag):
+    new_config = custom_config_file.parent / "new_config.yaml"
+    assert not new_config.exists()
+
+    new_config_path = str(new_config.absolute())
+
+    result = main(argv=[config_flag, new_config_path])
+
+    assert result == RESULT_SUCCESS
+    mock_commands_config.assert_called_once_with(new_config_path)
+
+
+def test_main_config(mock_commands_config):
+    result = main(argv=["config"])
+
+    assert result == RESULT_SUCCESS
+    mock_commands_config.assert_called_once_with(Config().current_path())
+
+
+def test_main_config_config_path(custom_config_file: Path, mock_commands_config):
+    new_config = custom_config_file.parent / "new_config.yaml"
+    assert not new_config.exists()
+
+    new_config_path = str(new_config.absolute())
+    result = main(argv=["config", new_config_path])
+
+    assert result == RESULT_SUCCESS
+    mock_commands_config.assert_called_once_with(new_config_path)
 
 
 @pytest.mark.parametrize("switch_type", CONFIG_TYPES)


### PR DESCRIPTION
Small fixes to config handling:

* In tests that call out to the CLI via `subprocess.call()`, ensure a real config file if present is not used
* Simplify changing config files via CLI:

_Before:_

```console
$ littlepay config -c /path/to/config.yaml
```

_This PR:_

```console
$ littlepay config /path/to/config.yaml
```

_or_

```console
$ littlepay -c /path/to/config.yaml
```