### PR TITLE
Feat: products

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,26 @@
-# Littlepay
+# Cal-ITP Littlepay
 
-APIs and admin tasks for Littlepay.
+Cal-ITP API implementations and admin tasks for Littlepay.
 
 ## Usage
 
 ```console
 $ littlepay -h
-usage: littlepay [-h] [-v] [-c CONFIG_PATH] {config,groups,switch} ...
+usage: littlepay [-h] [-v] [-c CONFIG_PATH] {config,groups,products,switch} ...
 
 positional arguments:
-  {config,groups,switch}
+  {config,groups,products,switch}
     config              Get or set configuration
     groups              Interact with groups in the active environment
+    products            Interact with products in the active environment
     switch              Switch the active environment or participant
 
 options:
   -h, --help            show this help message and exit
   -v, --version         show program's version number and exit
   -c CONFIG_PATH, --config CONFIG_PATH
-                        Path to a readable and writeable config file to use. File will be created if it does not exist.
+                        Path to a readable and writeable config file to use.
+                        File will be created if it does not exist.
 ```
 
 ## Install
@@ -26,7 +28,7 @@ options:
 Use `pip` to install from GitHub:
 
 ```console
-pip install git+https://github.com/cal-itp/littlepay.git@main"
+pip install git+https://github.com/cal-itp/littlepay.git@main
 ```
 
 ## Getting started
@@ -39,7 +41,7 @@ littlepay config
 
 The location and basic info from your current config file are printed in the terminal:
 
-```
+```console
 $ littlepay config
 Creating config file: /home/calitp/.littlepay/config.yaml
 Config: /home/calitp/.littlepay/config.yaml
@@ -88,7 +90,7 @@ littlepay config /path/to/new/config.yaml
 
 Or
 
-```
+```console
 littlepay --config /path/to/new/config.yaml
 ```
 
@@ -106,4 +108,169 @@ And `participants`:
 
 ```console
 littlepay switch participant <participant_id>
+```
+
+## Work with groups
+
+```console
+$ littlepay groups -h
+usage: littlepay groups [-h] [-f GROUP_TERMS] {create,link,products,remove,unlink} ...
+
+positional arguments:
+  {create,link,products,remove,unlink}
+    create              Create a new concession group
+    link                Link one or more concession groups to a product
+    products            List products for one or more concession groups
+    remove              Remove an existing concession group
+    unlink              Unlink a product from one or more concession groups
+
+options:
+  -h, --help            show this help message and exit
+  -f GROUP_TERMS, --filter GROUP_TERMS
+                        Filter for groups with matching group ID or label
+```
+
+### List existing groups
+
+Print all groups in the active environment:
+
+```console
+littlepay groups
+```
+
+Filter for groups with a matching ID or label:
+
+```console
+littlepay groups -f <term>
+```
+
+Multiple filters are OR'd together:
+
+```console
+littlepay groups -f <term1> -f <term2>
+```
+
+### Create a new group
+
+```console
+littlepay groups create <label>
+```
+
+### Delete an existing group
+
+With confirmation:
+
+```console
+littlepay groups remove <group_id>
+```
+
+Without confirmation:
+
+```console
+littlepay groups remove --force <group_id>
+```
+
+## Work with products
+
+```console
+$ littlepay products -h
+usage: littlepay products [-h] [-f PRODUCT_TERMS] [-s {ACTIVE,INACTIVE,EXPIRED}] {link,unlink} ...
+
+positional arguments:
+  {link,unlink}
+    link                Link one or more products to a concession group
+    unlink              Unlink a concession group from one or more products
+
+options:
+  -h, --help            show this help message and exit
+  -f PRODUCT_TERMS, --filter PRODUCT_TERMS
+                        Filter for products with matching product ID, code, or description
+  -s {ACTIVE,INACTIVE,EXPIRED}, --status {ACTIVE,INACTIVE,EXPIRED}
+                        Filter for products with matching status
+```
+
+### List existing products
+
+```console
+littlepay products
+```
+
+Filtering works the same as for groups, matching against product ID, code, or description:
+
+```console
+littlepay products -f <term>
+```
+
+```console
+littlepay products -f <term1> -f <term2>
+```
+
+Also supports filtering by status (`ACTIVE`, `INACTIVE`, `EXPIRED`):
+
+```console
+littlepay products -s EXPIRED
+```
+
+```console
+littlepay products -f <term> -s ACTIVE
+```
+
+### List linked products for one or more groups
+
+For each group, output the group's linked products. Builds on the filtering sytax.
+
+E.g. to list linked products for all groups:
+
+```console
+littlepay groups products
+```
+
+Or to list linked products for a specific group:
+
+```console
+littlepay groups -f <group_id> products
+```
+
+### Link and unlink a product to one or more groups
+
+For each group, link the given product to the group. Builds on the filtering syntax.
+
+E.g. to link a product to all groups:
+
+```console
+littlepay groups link <product_id>
+```
+
+Or to link a product to a specific group:
+
+```console
+littlepay groups -f <group_id> link <product_id>
+```
+
+Unlinking groups from a product works the same:
+
+```console
+littlepay groups -f <group_id> unlink <product_id>
+```
+
+### Link and unlink a group to one or more products
+
+For each product, link the given group to the product. Builds on the filtering syntax.
+
+E.g. to link a group to all products:
+
+```console
+littlepay products link <group_id>
+```
+
+Or to link a group to a specific product:
+
+```console
+littlepay products -f <product_id> link <group_id>
+```
+
+Unlinking products from a group works the same:
+
+```console
+littlepay products -f <product_id> unlink <group_id>
 ```

--- a/littlepay/api/__init__.py
+++ b/littlepay/api/__init__.py
@@ -60,8 +60,6 @@ class ClientProtocol(Protocol):
 
             endpoint (str): The fully-formed endpoint where the GET request should be made.
 
-            response_cls (TResponse): A dataclass representing the JSON response to the GET.
-
             Extra kwargs are passed as querystring params.
 
         Returns (TResponse):

--- a/littlepay/api/__init__.py
+++ b/littlepay/api/__init__.py
@@ -52,7 +52,7 @@ class ClientProtocol(Protocol):
         """
         pass
 
-    def _get_list(self, endpoint: str) -> Generator[dict, None, None]:
+    def _get_list(self, endpoint: str, **kwargs: dict) -> Generator[dict, None, None]:
         """Make a GET request to a JSON endpoint returning a ListResponse, yielding items from the resulting list.
 
         Args:
@@ -61,6 +61,8 @@ class ClientProtocol(Protocol):
             endpoint (str): The fully-formed endpoint where the GET request should be made.
 
             response_cls (TResponse): A dataclass representing the JSON response to the GET.
+
+            Extra kwargs are passed as querystring params.
 
         Returns (TResponse):
             A TResponse instance of the JSON response.

--- a/littlepay/api/client.py
+++ b/littlepay/api/client.py
@@ -150,4 +150,9 @@ class Client(ProductsMixin, GroupsMixin, ClientProtocol):
     def _post(self, endpoint: str, data: dict, response_cls: TResponse = dict, **kwargs) -> TResponse:
         response = self.oauth.post(endpoint, headers=self.headers, json=data, **kwargs)
         response.raise_for_status()
-        return response_cls(**response.json())
+        try:
+            # response body may be empty, cannot be decoded
+            data = response.json()
+        except json.JSONDecodeError:
+            data = {"status_code": response.status_code}
+        return response_cls(**data)

--- a/littlepay/api/client.py
+++ b/littlepay/api/client.py
@@ -8,6 +8,7 @@ from authlib.oauth2.rfc6749 import OAuth2Token
 from littlepay import __version__
 from littlepay.api import ClientProtocol, ListResponse, TResponse
 from littlepay.api.groups import GroupsMixin
+from littlepay.api.products import ProductsMixin
 from littlepay.config import Config
 
 
@@ -61,7 +62,7 @@ def _json_post_credentials(client, method, uri, headers, body) -> tuple:
     return uri, headers, json_data
 
 
-class Client(GroupsMixin, ClientProtocol):
+class Client(ProductsMixin, GroupsMixin, ClientProtocol):
     """Represents an API connection to an environment."""
 
     from_active_config = staticmethod(_client_from_active_config)
@@ -126,8 +127,9 @@ class Client(GroupsMixin, ClientProtocol):
         response.raise_for_status()
         return response_cls(**response.json())
 
-    def _get_list(self, endpoint: str) -> Generator[dict, None, None]:
+    def _get_list(self, endpoint: str, **kwargs) -> Generator[dict, None, None]:
         params = dict(page=1, perPage=100)
+        params.update(kwargs)
         total = 0
 
         data = self._get(endpoint, ListResponse, **params)

--- a/littlepay/api/products.py
+++ b/littlepay/api/products.py
@@ -1,0 +1,30 @@
+from dataclasses import dataclass
+from typing import Generator
+
+from littlepay.api import ClientProtocol
+
+
+@dataclass
+class ProductResponse:
+    id: str
+    code: str
+    status: str
+    type: str
+    description: str
+    participant_id: str
+
+
+class ProductsMixin(ClientProtocol):
+    """Mixin implements APIs for products."""
+
+    PRODUCTS = "products"
+
+    def get_products(self, product_id: str = None, status: str = None) -> Generator[ProductResponse, None, None]:
+        """Yield ProductResponse objects from the products endpoint."""
+        endpoint = self.products_endpoint(product_id)
+        for item in self._get_list(endpoint, status=status):
+            yield ProductResponse(**item)
+
+    def products_endpoint(self, product_id: str = None) -> str:
+        """Endpoint for products."""
+        return self._make_endpoint(self.PRODUCTS, product_id)

--- a/littlepay/api/products.py
+++ b/littlepay/api/products.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from typing import Generator
 
 from littlepay.api import ClientProtocol
+from littlepay.api.groups import GroupsMixin
 
 
 @dataclass
@@ -14,16 +15,30 @@ class ProductResponse:
     participant_id: str
 
 
-class ProductsMixin(ClientProtocol):
+class ProductsMixin(GroupsMixin, ClientProtocol):
     """Mixin implements APIs for products."""
 
     PRODUCTS = "products"
 
+    def concession_group_products_endpoint(self, group_id: str, product_id: str = None) -> str:
+        """Endpoint for a concession group's products. Optionally provide a product_id for a product-specific endpoint."""
+        return self.concession_groups_endpoint(group_id, self.PRODUCTS, product_id)
+
+    def get_concession_group_products(self, group_id: str) -> Generator[ProductResponse, None, None]:
+        """Yield ProductResponse objects from the concession_group's products endpoint."""
+        endpoint = self.concession_group_products_endpoint(group_id)
+        for item in self._get_list(endpoint):
+            for product in self.get_products(item["id"]):
+                yield product
+
     def get_products(self, product_id: str = None, status: str = None) -> Generator[ProductResponse, None, None]:
         """Yield ProductResponse objects from the products endpoint."""
         endpoint = self.products_endpoint(product_id)
-        for item in self._get_list(endpoint, status=status):
-            yield ProductResponse(**item)
+        if product_id is None:
+            for item in self._get_list(endpoint, status=status):
+                yield ProductResponse(**item)
+        else:
+            yield self._get(endpoint, ProductResponse)
 
     def products_endpoint(self, product_id: str = None) -> str:
         """Endpoint for products."""

--- a/littlepay/api/products.py
+++ b/littlepay/api/products.py
@@ -40,6 +40,17 @@ class ProductsMixin(GroupsMixin, ClientProtocol):
         else:
             yield self._get(endpoint, ProductResponse)
 
+    def link_concession_group_product(self, group_id: str, product_id: str) -> dict:
+        """Link a product to a concession group."""
+        endpoint = self.concession_group_products_endpoint(group_id)
+        data = {"id": product_id}
+        return self._post(endpoint, data, dict)
+
     def products_endpoint(self, product_id: str = None) -> str:
         """Endpoint for products."""
         return self._make_endpoint(self.PRODUCTS, product_id)
+
+    def unlink_concession_group_product(self, group_id: str, product_id: str) -> bool:
+        """Unlink a product from a concession group."""
+        endpoint = self.concession_group_products_endpoint(group_id, product_id)
+        return self._delete(endpoint)

--- a/littlepay/commands/groups.py
+++ b/littlepay/commands/groups.py
@@ -33,6 +33,13 @@ def groups(args: Namespace = None) -> int:
             groups,
         )
 
+    if command == "link":
+        for group in groups:
+            link_product(client, group.id, args.product_id)
+    elif command == "unlink":
+        for group in groups:
+            unlink_product(client, group.id, args.product_id)
+
     groups = list(groups)
     print_active_message(config, f"👥 Matching groups ({len(groups)})")
 
@@ -49,6 +56,7 @@ def groups(args: Namespace = None) -> int:
 
 def create_group(client: Client, group_label: str):
     print_active_message(config, "Creating group", f"[{group_label}]")
+
     try:
         result = client.create_concession_group(group_label)
         print(f"✅ Created: {result}")
@@ -76,3 +84,23 @@ def remove_group(client: Client, group_id: str, force: bool = False):
             print(f"❌ Error: {err}")
     else:
         print("Canceled...")
+
+
+def link_product(client: Client, group_id: str, product_id: str):
+    print_active_message(config, "Linking group <-> product", f"[{group_id}] <-> [{product_id}]")
+
+    try:
+        result = client.link_concession_group_product(group_id, product_id)
+        print(f"✅ Linked: {result}")
+    except HTTPError as err:
+        print(f"❌ Error: {err}")
+
+
+def unlink_product(client: Client, group_id: str, product_id: str):
+    print_active_message(config, "Unlinking group <-> product", f"[{group_id}] <-> [{product_id}]")
+
+    try:
+        client.unlink_concession_group_product(group_id, product_id)
+        print("✅ Unlinked")
+    except HTTPError as err:
+        print(f"❌ Error: {err}")

--- a/littlepay/commands/groups.py
+++ b/littlepay/commands/groups.py
@@ -38,6 +38,11 @@ def groups(args: Namespace = None) -> int:
 
     for group in groups:
         print(group)
+        if command == "products":
+            products = list(client.get_concession_group_products(group.id))
+            print(f"  🛒 Linked products ({len(products)})")
+            for product in products:
+                print(" ", product)
 
     return RESULT_SUCCESS
 

--- a/littlepay/commands/groups.py
+++ b/littlepay/commands/groups.py
@@ -3,13 +3,14 @@ from argparse import Namespace
 from requests import HTTPError
 
 from littlepay.api.client import Client
-from littlepay.commands import RESULT_SUCCESS, print_active_message
+from littlepay.commands import RESULT_FAILURE, RESULT_SUCCESS, print_active_message
 from littlepay.config import Config
 
 config = Config()
 
 
 def groups(args: Namespace = None) -> int:
+    return_code = RESULT_SUCCESS
     client = Client.from_active_config(config)
     client.oauth.ensure_active_token(client.token)
     config.active_token = client.token
@@ -20,9 +21,9 @@ def groups(args: Namespace = None) -> int:
         command = None
 
     if command == "create":
-        create_group(client, args.group_label)
+        return_code += create_group(client, args.group_label)
     elif command == "remove":
-        remove_group(client, args.group_id, getattr(args, "force", False))
+        return_code += remove_group(client, args.group_id, getattr(args, "force", False))
 
     groups = client.get_concession_groups()
 
@@ -35,10 +36,10 @@ def groups(args: Namespace = None) -> int:
 
     if command == "link":
         for group in groups:
-            link_product(client, group.id, args.product_id)
+            return_code += link_product(client, group.id, args.product_id)
     elif command == "unlink":
         for group in groups:
-            unlink_product(client, group.id, args.product_id)
+            return_code += unlink_product(client, group.id, args.product_id)
 
     groups = list(groups)
     print_active_message(config, f"👥 Matching groups ({len(groups)})")
@@ -51,21 +52,26 @@ def groups(args: Namespace = None) -> int:
             for product in products:
                 print(" ", product)
 
-    return RESULT_SUCCESS
+    return RESULT_SUCCESS if return_code == RESULT_SUCCESS else RESULT_FAILURE
 
 
-def create_group(client: Client, group_label: str):
+def create_group(client: Client, group_label: str) -> int:
     print_active_message(config, "Creating group", f"[{group_label}]")
+    return_code = RESULT_SUCCESS
 
     try:
         result = client.create_concession_group(group_label)
         print(f"✅ Created: {result}")
     except HTTPError as err:
         print(f"❌ Error: {err}")
+        return_code = RESULT_FAILURE
+
+    return return_code
 
 
-def remove_group(client: Client, group_id: str, force: bool = False):
+def remove_group(client: Client, group_id: str, force: bool = False) -> int:
     print_active_message(config, "Removing group", f"[{group_id}]")
+    return_code = RESULT_SUCCESS
 
     if force is True:
         confirm = "yes"
@@ -82,25 +88,36 @@ def remove_group(client: Client, group_id: str, force: bool = False):
             print("✅ Removed")
         except HTTPError as err:
             print(f"❌ Error: {err}")
+            return_code = RESULT_FAILURE
     else:
         print("Canceled...")
 
+    return return_code
 
-def link_product(client: Client, group_id: str, product_id: str):
+
+def link_product(client: Client, group_id: str, product_id: str) -> int:
     print_active_message(config, "Linking group <-> product", f"[{group_id}] <-> [{product_id}]")
+    return_code = RESULT_SUCCESS
 
     try:
         result = client.link_concession_group_product(group_id, product_id)
         print(f"✅ Linked: {result}")
     except HTTPError as err:
         print(f"❌ Error: {err}")
+        return_code = RESULT_FAILURE
+
+    return return_code
 
 
-def unlink_product(client: Client, group_id: str, product_id: str):
+def unlink_product(client: Client, group_id: str, product_id: str) -> int:
     print_active_message(config, "Unlinking group <-> product", f"[{group_id}] <-> [{product_id}]")
+    return_code = RESULT_SUCCESS
 
     try:
         client.unlink_concession_group_product(group_id, product_id)
         print("✅ Unlinked")
     except HTTPError as err:
         print(f"❌ Error: {err}")
+        return_code = RESULT_FAILURE
+
+    return return_code

--- a/littlepay/commands/products.py
+++ b/littlepay/commands/products.py
@@ -2,6 +2,7 @@ from argparse import Namespace
 
 from littlepay.api.client import Client
 from littlepay.commands import RESULT_SUCCESS, print_active_message
+from littlepay.commands.groups import link_product, unlink_product
 from littlepay.config import Config
 
 config = Config()
@@ -11,6 +12,11 @@ def products(args: Namespace = None) -> int:
     client = Client.from_active_config(config)
     client.oauth.ensure_active_token(client.token)
     config.active_token = client.token
+
+    if hasattr(args, "product_command"):
+        command = args.product_command
+    else:
+        command = None
 
     if hasattr(args, "product_status") and args.product_status is not None:
         status = args.product_status
@@ -33,5 +39,12 @@ def products(args: Namespace = None) -> int:
 
     for product in products:
         print(product)
+
+    if command == "link":
+        for product in products:
+            link_product(client, args.group_id, product.id)
+    elif command == "unlink":
+        for product in products:
+            unlink_product(client, args.group_id, product.id)
 
     return RESULT_SUCCESS

--- a/littlepay/commands/products.py
+++ b/littlepay/commands/products.py
@@ -1,0 +1,37 @@
+from argparse import Namespace
+
+from littlepay.api.client import Client
+from littlepay.commands import RESULT_SUCCESS, print_active_message
+from littlepay.config import Config
+
+config = Config()
+
+
+def products(args: Namespace = None) -> int:
+    client = Client.from_active_config(config)
+    client.oauth.ensure_active_token(client.token)
+    config.active_token = client.token
+
+    if hasattr(args, "product_status") and args.product_status is not None:
+        status = args.product_status
+    else:
+        status = None
+
+    products = client.get_products(status=status)
+
+    if hasattr(args, "product_terms") and args.product_terms is not None:
+        terms = [t.lower() for t in args.product_terms if t]
+        products = filter(
+            lambda p: any(
+                [any((term in p.id.lower(), term in p.code.lower(), term in p.description.lower())) for term in terms]
+            ),
+            products,
+        )
+
+    products = list(products)
+    print_active_message(config, f"🛒 Matching products ({len(products)})")
+
+    for product in products:
+        print(product)
+
+    return RESULT_SUCCESS

--- a/littlepay/commands/products.py
+++ b/littlepay/commands/products.py
@@ -1,7 +1,7 @@
 from argparse import Namespace
 
 from littlepay.api.client import Client
-from littlepay.commands import RESULT_SUCCESS, print_active_message
+from littlepay.commands import RESULT_FAILURE, RESULT_SUCCESS, print_active_message
 from littlepay.commands.groups import link_product, unlink_product
 from littlepay.config import Config
 
@@ -9,6 +9,7 @@ config = Config()
 
 
 def products(args: Namespace = None) -> int:
+    return_code = RESULT_SUCCESS
     client = Client.from_active_config(config)
     client.oauth.ensure_active_token(client.token)
     config.active_token = client.token
@@ -42,9 +43,9 @@ def products(args: Namespace = None) -> int:
 
     if command == "link":
         for product in products:
-            link_product(client, args.group_id, product.id)
+            return_code += link_product(client, args.group_id, product.id)
     elif command == "unlink":
         for product in products:
-            unlink_product(client, args.group_id, product.id)
+            return_code += unlink_product(client, args.group_id, product.id)
 
-    return RESULT_SUCCESS
+    return RESULT_SUCCESS if return_code == RESULT_SUCCESS else RESULT_FAILURE

--- a/littlepay/main.py
+++ b/littlepay/main.py
@@ -46,7 +46,7 @@ def main(argv=None):
     config_parser = _maincmd("config", help="Get or set configuration")
     config_parser.add_argument("config_path", nargs="?", default=Config.current_path())
 
-    # littlepay groups [-f GROUP] [{create,remove}] [...]
+    # littlepay groups [-f GROUP] [{create,products,remove}] [...]
     groups_parser = _maincmd("groups", help="Interact with groups in the active environment")
     groups_parser.add_argument(
         "-f", "--filter", help="Filter for groups with matching group ID or label", dest="group_terms", action="append"
@@ -56,6 +56,8 @@ def main(argv=None):
 
     groups_create = _subcmd(groups_commands, "create", help="Create a new concession group")
     groups_create.add_argument("group_label", help="A unique label associated with the concession group", metavar="LABEL")
+
+    _subcmd(groups_commands, "products", help="List products for one or more concession groups")
 
     groups_remove = _subcmd(groups_commands, "remove", help="Remove an existing concession group")
     groups_remove.add_argument("--force", action="store_true", default=False, help="Don't ask for confirmation before removal")

--- a/littlepay/main.py
+++ b/littlepay/main.py
@@ -4,6 +4,7 @@ import sys
 from littlepay import __version__ as version
 from littlepay.commands.configure import configure
 from littlepay.commands.groups import groups
+from littlepay.commands.products import products
 from littlepay.commands.switch import switch
 from littlepay.config import CONFIG_TYPES, Config
 
@@ -60,6 +61,23 @@ def main(argv=None):
     groups_remove.add_argument("--force", action="store_true", default=False, help="Don't ask for confirmation before removal")
     groups_remove.add_argument("group_id", help="The ID of the concession group to remove", metavar="ID")
 
+    # littlepay products [-f PRODUCT] [-s STATUS]
+    products_parser = _maincmd("products", help="Interact with products in the active environment")
+    products_parser.add_argument(
+        "-f",
+        "--filter",
+        help="Filter for products with matching product ID, code, or description",
+        dest="product_terms",
+        action="append",
+    )
+    products_parser.add_argument(
+        "-s",
+        "--status",
+        help="Filter for products with matching status",
+        choices=["ACTIVE", "INACTIVE", "EXPIRED"],
+        dest="product_status",
+    )
+
     # littlepay switch {env, participant} VALUE
     switch_parser = _maincmd("switch", help="Switch the active environment or participant")
     switch_parser.add_argument("switch_type", choices=CONFIG_TYPES, help="The type of object to switch", metavar="TYPE")
@@ -74,6 +92,8 @@ def main(argv=None):
         return configure(args.config_path)
     elif args.command == "groups":
         return groups(args)
+    elif args.command == "products":
+        return products(args)
     elif args.command == "switch":
         return switch(args.switch_type, args.switch_arg)
 

--- a/littlepay/main.py
+++ b/littlepay/main.py
@@ -46,7 +46,7 @@ def main(argv=None):
     config_parser = _maincmd("config", help="Get or set configuration")
     config_parser.add_argument("config_path", nargs="?", default=Config.current_path())
 
-    # littlepay groups [-f GROUP] [{create,products,remove}] [...]
+    # littlepay groups [-f GROUP] [{create,link,products,remove,unlink}] [...]
     groups_parser = _maincmd("groups", help="Interact with groups in the active environment")
     groups_parser.add_argument(
         "-f", "--filter", help="Filter for groups with matching group ID or label", dest="group_terms", action="append"
@@ -57,13 +57,19 @@ def main(argv=None):
     groups_create = _subcmd(groups_commands, "create", help="Create a new concession group")
     groups_create.add_argument("group_label", help="A unique label associated with the concession group", metavar="LABEL")
 
+    groups_link = _subcmd(groups_commands, "link", help="Link one or more concession groups to a product")
+    groups_link.add_argument("product_id", help="The ID of the product to link to")
+
     _subcmd(groups_commands, "products", help="List products for one or more concession groups")
 
     groups_remove = _subcmd(groups_commands, "remove", help="Remove an existing concession group")
     groups_remove.add_argument("--force", action="store_true", default=False, help="Don't ask for confirmation before removal")
     groups_remove.add_argument("group_id", help="The ID of the concession group to remove", metavar="ID")
 
-    # littlepay products [-f PRODUCT] [-s STATUS]
+    groups_unlink = _subcmd(groups_commands, "unlink", help="Unlink a product from one or more concession groups")
+    groups_unlink.add_argument("product_id", help="The ID of the product to unlink")
+
+    # littlepay products [-f PRODUCT] [-s STATUS] [{link,unlink}] [...]
     products_parser = _maincmd("products", help="Interact with products in the active environment")
     products_parser.add_argument(
         "-f",
@@ -79,6 +85,14 @@ def main(argv=None):
         choices=["ACTIVE", "INACTIVE", "EXPIRED"],
         dest="product_status",
     )
+
+    products_commands = products_parser.add_subparsers(dest="product_command", required=False)
+
+    products_link = _subcmd(products_commands, "link", help="Link one or more products to a concession group")
+    products_link.add_argument("group_id", help="The ID of the concession group to link to")
+
+    products_unlink = _subcmd(products_commands, "unlink", help="Unlink a concession group from one or more products")
+    products_unlink.add_argument("group_id", help="The ID of the concession group to unlink")
 
     # littlepay switch {env, participant} VALUE
     switch_parser = _maincmd("switch", help="Switch the active environment or participant")

--- a/tests/api/test_client.py
+++ b/tests/api/test_client.py
@@ -290,11 +290,11 @@ def test_Client_make_endpoint(make_client: ClientFunc, url):
 
 def test_Client_make_endpoint_None(make_client: ClientFunc, url):
     client = make_client()
-    partial = ("partial", None, "123.json")
+    parts = ("one", None, "two", None)
 
-    result = client._make_endpoint(*partial)
+    result = client._make_endpoint(*parts)
 
-    assert result == f"{url}/api/v1/partial/123.json"
+    assert result == f"{url}/api/v1/one/two"
 
 
 def test_Client_make_endpoint_version(make_client: ClientFunc, url, version):

--- a/tests/api/test_groups.py
+++ b/tests/api/test_groups.py
@@ -1,11 +1,8 @@
 from typing import Generator
+
 import pytest
+
 from littlepay.api.groups import GroupResponse, GroupsMixin
-
-
-@pytest.fixture
-def mock_ClientProtocol_delete(mocker):
-    return mocker.patch("littlepay.api.ClientProtocol._delete", side_effect=lambda *args, **kwargs: True)
 
 
 @pytest.fixture
@@ -16,14 +13,6 @@ def mock_ClientProtocol_get_list_Groups(mocker):
         dict(id="2", label="two", participant_id="two_2"),
     ]
     return mocker.patch("littlepay.api.ClientProtocol._get_list", side_effect=lambda *args, **kwargs: (g for g in items))
-
-
-@pytest.fixture(autouse=True)
-def mock_ClientProtocol_make_endpoint(mocker, url):
-    # patch _make_endpoint to create a endpoint for example.com
-    mocker.patch(
-        "littlepay.api.ClientProtocol._make_endpoint", side_effect=lambda *args: f"{url}/{'/'.join([a for a in args if a])}"
-    )
 
 
 @pytest.fixture

--- a/tests/api/test_products.py
+++ b/tests/api/test_products.py
@@ -16,16 +16,54 @@ def mock_ClientProtocol_get_list(mocker):
     return mocker.patch("littlepay.api.ClientProtocol._get_list", side_effect=lambda *args, **kwargs: (g for g in PRODUCTS))
 
 
-def test_ProductsMixin_products_endpoint(url):
+@pytest.fixture
+def mock_ClientProtocol_get_list_ProductResponse(mocker):
+    return mocker.patch(
+        "littlepay.api.ClientProtocol._get_list", side_effect=lambda *args, **kwargs: (ProductResponse(**p) for p in PRODUCTS)
+    )
+
+
+@pytest.fixture
+def mock_ClientProtocol_get_Product(mocker):
+    return mocker.patch(
+        "littlepay.api.ClientProtocol._get", side_effect=lambda *args, **kwargs: (ProductResponse(**p) for p in PRODUCTS[0:1])
+    )
+
+
+@pytest.fixture
+def mock_ProductsMixin_get_products(mocker):
+    return mocker.patch(
+        "littlepay.api.products.ProductsMixin.get_products",
+        # fake a generator for a single item
+        side_effect=lambda item_id: (ProductResponse(**item) for item in PRODUCTS if item["id"] == item_id),
+    )
+
+
+def test_ProductsMixin_concession_groups_products_endpoint(url):
     client = ProductsMixin()
 
-    assert client.products_endpoint() == f"{url}/products"
+    assert client.concession_group_products_endpoint("1234") == f"{url}/concession_groups/1234/products"
 
 
-def test_ProductsMixin_products_endpoint_id(url):
+def test_ProductsMixin_concession_groups_products_endpoint_product_id(url):
     client = ProductsMixin()
 
-    assert client.products_endpoint("1234") == f"{url}/products/1234"
+    assert client.concession_group_products_endpoint("1234", "5678") == f"{url}/concession_groups/1234/products/5678"
+
+
+def test_ProductsMixin_get_concession_group_products(mock_ClientProtocol_get_list, mock_ProductsMixin_get_products):
+    client = ProductsMixin()
+
+    result = client.get_concession_group_products("1234")
+    assert isinstance(result, Generator)
+    assert mock_ClientProtocol_get_list.call_count == 0
+    assert mock_ProductsMixin_get_products.call_count == 0
+
+    result_list = list(result)
+    mock_ClientProtocol_get_list.assert_called_once_with(client.concession_group_products_endpoint("1234"))
+    assert mock_ProductsMixin_get_products.call_count == len(PRODUCTS)
+    assert len(result_list) == len(PRODUCTS)
+    assert all([isinstance(item, ProductResponse) for item in result_list])
 
 
 def test_ProductsMixin_get_products(mock_ClientProtocol_get_list):
@@ -37,15 +75,27 @@ def test_ProductsMixin_get_products(mock_ClientProtocol_get_list):
 
     result_list = list(result)
     mock_ClientProtocol_get_list.assert_called_once_with(client.products_endpoint(), status=None)
-    assert len(result_list) == 3
+    assert len(result_list) == len(PRODUCTS)
     assert all([isinstance(item, ProductResponse) for item in result_list])
 
 
-def test_ProductsMixin_get_products_product_id(url, mock_ClientProtocol_get_list):
+def test_ProductsMixin_get_products_product_id(url, mock_ClientProtocol_get_Product):
     client = ProductsMixin()
 
     result = client.get_products("1234")
     assert isinstance(result, Generator)
 
     for _ in result:
-        mock_ClientProtocol_get_list.assert_called_once_with(f"{url}/products/1234", status=None)
+        mock_ClientProtocol_get_Product.assert_called_once_with(f"{url}/products/1234", ProductResponse)
+
+
+def test_ProductsMixin_products_endpoint(url):
+    client = ProductsMixin()
+
+    assert client.products_endpoint() == f"{url}/products"
+
+
+def test_ProductsMixin_products_endpoint_id(url):
+    client = ProductsMixin()
+
+    assert client.products_endpoint("1234") == f"{url}/products/1234"

--- a/tests/api/test_products.py
+++ b/tests/api/test_products.py
@@ -39,6 +39,12 @@ def mock_ProductsMixin_get_products(mocker):
     )
 
 
+@pytest.fixture
+def mock_ClientProtocol_post(mocker):
+    response = {"status_code": 201}
+    return mocker.patch("littlepay.api.ClientProtocol._post", side_effect=lambda *args, **kwargs: response)
+
+
 def test_ProductsMixin_concession_groups_products_endpoint(url):
     client = ProductsMixin()
 
@@ -89,6 +95,15 @@ def test_ProductsMixin_get_products_product_id(url, mock_ClientProtocol_get_Prod
         mock_ClientProtocol_get_Product.assert_called_once_with(f"{url}/products/1234", ProductResponse)
 
 
+def test_ProductsMixin_link_concession_group_product(mock_ClientProtocol_post):
+    client = ProductsMixin()
+    result = client.link_concession_group_product("group-1234", "product-1234")
+
+    endpoint = client.concession_group_products_endpoint("group-1234")
+    mock_ClientProtocol_post.assert_called_once_with(endpoint, {"id": "product-1234"}, dict)
+    assert result == {"status_code": 201}
+
+
 def test_ProductsMixin_products_endpoint(url):
     client = ProductsMixin()
 
@@ -99,3 +114,12 @@ def test_ProductsMixin_products_endpoint_id(url):
     client = ProductsMixin()
 
     assert client.products_endpoint("1234") == f"{url}/products/1234"
+
+
+def test_ProductsMixin_unlink_concession_group_product(mock_ClientProtocol_delete):
+    client = ProductsMixin()
+    result = client.unlink_concession_group_product("group-1234", "product-1234")
+
+    endpoint = client.concession_group_products_endpoint("group-1234", "product-1234")
+    mock_ClientProtocol_delete.assert_called_once_with(endpoint)
+    assert result is True

--- a/tests/api/test_products.py
+++ b/tests/api/test_products.py
@@ -1,0 +1,51 @@
+from typing import Generator
+
+import pytest
+
+from littlepay.api.products import ProductsMixin, ProductResponse
+
+PRODUCTS = [
+    dict(id="0", code="zero", status="ACTIVE", type="CAPPING", description="zero cap", participant_id="zero_0"),
+    dict(id="1", code="one", status="INACTIVE", type="DISCOUNT", description="one discount", participant_id="one_1"),
+    dict(id="2", code="two", status="EXPIRED", type="CAPPING", description="two expired caps", participant_id="two_2"),
+]
+
+
+@pytest.fixture
+def mock_ClientProtocol_get_list(mocker):
+    return mocker.patch("littlepay.api.ClientProtocol._get_list", side_effect=lambda *args, **kwargs: (g for g in PRODUCTS))
+
+
+def test_ProductsMixin_products_endpoint(url):
+    client = ProductsMixin()
+
+    assert client.products_endpoint() == f"{url}/products"
+
+
+def test_ProductsMixin_products_endpoint_id(url):
+    client = ProductsMixin()
+
+    assert client.products_endpoint("1234") == f"{url}/products/1234"
+
+
+def test_ProductsMixin_get_products(mock_ClientProtocol_get_list):
+    client = ProductsMixin()
+
+    result = client.get_products()
+    assert isinstance(result, Generator)
+    assert mock_ClientProtocol_get_list.call_count == 0
+
+    result_list = list(result)
+    mock_ClientProtocol_get_list.assert_called_once_with(client.products_endpoint(), status=None)
+    assert len(result_list) == 3
+    assert all([isinstance(item, ProductResponse) for item in result_list])
+
+
+def test_ProductsMixin_get_products_product_id(url, mock_ClientProtocol_get_list):
+    client = ProductsMixin()
+
+    result = client.get_products("1234")
+    assert isinstance(result, Generator)
+
+    for _ in result:
+        mock_ClientProtocol_get_list.assert_called_once_with(f"{url}/products/1234", status=None)

--- a/tests/commands/test_groups.py
+++ b/tests/commands/test_groups.py
@@ -101,7 +101,7 @@ def test_groups_group_command__create(mock_client, capfd):
     assert "Matching groups" in capture.out
 
 
-def test_groups_group_command__create_error(mock_client, capfd):
+def test_groups_group_command__create_HTTPError(mock_client, capfd):
     mock_client.create_concession_group.side_effect = HTTPError
 
     args = Namespace(group_command="create", group_label="the-label")
@@ -114,6 +114,32 @@ def test_groups_group_command__create_error(mock_client, capfd):
     assert "Creating group" in capture.out
     assert "Error" in capture.out
     assert "Matching groups" in capture.out
+
+
+def test_groups_group_command__link(mock_client, capfd):
+    args = Namespace(group_command="link", product_id="1234")
+    res = groups(args)
+    capture = capfd.readouterr()
+
+    for group in GROUP_RESPONSES:
+        mock_client.link_concession_group_product.assert_any_call(group.id, "1234")
+
+    assert res == RESULT_SUCCESS
+    assert "Linking group <-> product" in capture.out
+    assert "Linked" in capture.out
+
+
+def test_groups_group_command__link_HTTPError(mock_client, capfd):
+    mock_client.link_concession_group_product.side_effect = HTTPError
+
+    args = Namespace(group_command="link", product_id="1234")
+    res = groups(args)
+    capture = capfd.readouterr()
+
+    assert res == RESULT_SUCCESS
+    assert "Linking group <-> product" in capture.out
+    assert "Error" in capture.out
+    assert "Linked" not in capture.out
 
 
 def test_groups_group_command__products(mock_client, capfd):
@@ -203,3 +229,29 @@ def test_groups_group_command__remove_HTTPError(capfd, mock_client, mock_input):
     assert "Removing group" in capture.out
     assert "Error" in capture.out
     assert "Matching groups" in capture.out
+
+
+def test_groups_group_command__unlink(mock_client, capfd):
+    args = Namespace(group_command="unlink", product_id="1234")
+    res = groups(args)
+    capture = capfd.readouterr()
+
+    for group in GROUP_RESPONSES:
+        mock_client.unlink_concession_group_product.assert_any_call(group.id, "1234")
+
+    assert res == RESULT_SUCCESS
+    assert "Unlinking group <-> product" in capture.out
+    assert "Unlinked" in capture.out
+
+
+def test_groups_group_command__unlink_HTTPError(mock_client, capfd):
+    mock_client.unlink_concession_group_product.side_effect = HTTPError
+
+    args = Namespace(group_command="unlink", product_id="1234")
+    res = groups(args)
+    capture = capfd.readouterr()
+
+    assert res == RESULT_SUCCESS
+    assert "Unlinking group <-> product" in capture.out
+    assert "Error" in capture.out
+    assert "Unlinked" not in capture.out

--- a/tests/commands/test_groups.py
+++ b/tests/commands/test_groups.py
@@ -7,6 +7,8 @@ from littlepay.api.groups import GroupResponse
 from littlepay.commands import RESULT_SUCCESS
 from littlepay.commands.groups import groups
 
+from tests.commands.test_products import PRODUCT_RESPONSES
+
 GROUP_RESPONSES = [
     GroupResponse("id0", "zero", "participant123"),
     GroupResponse("id1", "one", "participant123"),
@@ -112,6 +114,25 @@ def test_groups_group_command__create_error(mock_client, capfd):
     assert "Creating group" in capture.out
     assert "Error" in capture.out
     assert "Matching groups" in capture.out
+
+
+def test_groups_group_command__products(mock_client, capfd):
+    # fake a generator for a single item
+    mock_client.get_concession_group_products.return_value = (p for p in PRODUCT_RESPONSES if PRODUCT_RESPONSES.index(p) == 0)
+
+    args = Namespace(group_command="products", group_id="1234")
+    res = groups(args)
+    capture = capfd.readouterr()
+
+    mock_client.get_concession_group_products.call_count == len(GROUP_RESPONSES)
+
+    assert res == RESULT_SUCCESS
+    assert "Linked products (1)" in capture.out
+    for product in PRODUCT_RESPONSES:
+        if PRODUCT_RESPONSES.index(product) == 0:
+            assert str(product) in capture.out
+        else:
+            assert str(product) not in capture.out
 
 
 @pytest.mark.parametrize("sample_input", ["y", "Y", "yes", "Yes", "YES"])

--- a/tests/commands/test_groups.py
+++ b/tests/commands/test_groups.py
@@ -4,7 +4,7 @@ import pytest
 from requests import HTTPError
 
 from littlepay.api.groups import GroupResponse
-from littlepay.commands import RESULT_SUCCESS
+from littlepay.commands import RESULT_FAILURE, RESULT_SUCCESS
 from littlepay.commands.groups import groups
 
 from tests.commands.test_products import PRODUCT_RESPONSES
@@ -110,7 +110,7 @@ def test_groups_group_command__create_HTTPError(mock_client, capfd):
 
     mock_client.create_concession_group.assert_called_once_with("the-label")
 
-    assert res == RESULT_SUCCESS
+    assert res == RESULT_FAILURE
     assert "Creating group" in capture.out
     assert "Error" in capture.out
     assert "Matching groups" in capture.out
@@ -136,7 +136,7 @@ def test_groups_group_command__link_HTTPError(mock_client, capfd):
     res = groups(args)
     capture = capfd.readouterr()
 
-    assert res == RESULT_SUCCESS
+    assert res == RESULT_FAILURE
     assert "Linking group <-> product" in capture.out
     assert "Error" in capture.out
     assert "Linked" not in capture.out
@@ -225,7 +225,7 @@ def test_groups_group_command__remove_HTTPError(capfd, mock_client, mock_input):
     res = groups(args)
     capture = capfd.readouterr()
 
-    assert res == RESULT_SUCCESS
+    assert res == RESULT_FAILURE
     assert "Removing group" in capture.out
     assert "Error" in capture.out
     assert "Matching groups" in capture.out
@@ -251,7 +251,7 @@ def test_groups_group_command__unlink_HTTPError(mock_client, capfd):
     res = groups(args)
     capture = capfd.readouterr()
 
-    assert res == RESULT_SUCCESS
+    assert res == RESULT_FAILURE
     assert "Unlinking group <-> product" in capture.out
     assert "Error" in capture.out
     assert "Unlinked" not in capture.out

--- a/tests/commands/test_groups.py
+++ b/tests/commands/test_groups.py
@@ -1,4 +1,5 @@
 from argparse import Namespace
+
 import pytest
 from requests import HTTPError
 
@@ -52,8 +53,10 @@ def test_groups_default(mock_client, capfd):
 
 
 @pytest.mark.parametrize("group_response", GROUP_RESPONSES)
-def test_groups_group_terms__group_id(group_response, capfd):
-    args = Namespace(group_terms=[group_response.id])
+@pytest.mark.parametrize("filter_attribute", ["id", "label"])
+def test_groups_group_terms(group_response, filter_attribute, capfd):
+    filter_value = getattr(group_response, filter_attribute)
+    args = Namespace(group_terms=[filter_value])
     res = groups(args)
     capture = capfd.readouterr()
 
@@ -67,23 +70,7 @@ def test_groups_group_terms__group_id(group_response, capfd):
             assert str(response) not in capture.out
 
 
-@pytest.mark.parametrize("group_response", GROUP_RESPONSES)
-def test_groups_group_terms__group_label(group_response, capfd):
-    args = Namespace(group_terms=[group_response.label])
-    res = groups(args)
-    capture = capfd.readouterr()
-
-    assert res == RESULT_SUCCESS
-
-    assert "Matching groups (1)" in capture.out
-    for response in GROUP_RESPONSES:
-        if response == group_response:
-            assert str(response) in capture.out
-        else:
-            assert str(response) not in capture.out
-
-
-def test_groups_group_terms__multiple(capfd):
+def test_groups_group_terms_multiple(capfd):
     terms = [GROUP_RESPONSES[0].id, GROUP_RESPONSES[1].label]
     args = Namespace(group_terms=terms)
     res = groups(args)

--- a/tests/commands/test_products.py
+++ b/tests/commands/test_products.py
@@ -45,6 +45,32 @@ def test_products_default(mock_client, capfd):
         assert str(response) in capture.out
 
 
+def test_products_product_command__link(mock_client, capfd):
+    args = Namespace(product_command="link", group_id="1234")
+    res = products(args)
+    capture = capfd.readouterr()
+
+    for product in PRODUCT_RESPONSES:
+        mock_client.link_concession_group_product.assert_any_call("1234", product.id)
+
+    assert res == RESULT_SUCCESS
+    assert "Linking group <-> product" in capture.out
+    assert "Linked" in capture.out
+
+
+def test_products_product_command__unlink(mock_client, capfd):
+    args = Namespace(product_command="unlink", group_id="1234")
+    res = products(args)
+    capture = capfd.readouterr()
+
+    for product in PRODUCT_RESPONSES:
+        mock_client.unlink_concession_group_product.assert_any_call("1234", product.id)
+
+    assert res == RESULT_SUCCESS
+    assert "Unlinking group <-> product" in capture.out
+    assert "Unlinked" in capture.out
+
+
 @pytest.mark.parametrize("product_response", PRODUCT_RESPONSES)
 def test_products_product_status(mock_client, product_response, capfd):
     args = Namespace(product_status=product_response.status)

--- a/tests/commands/test_products.py
+++ b/tests/commands/test_products.py
@@ -1,0 +1,91 @@
+from argparse import Namespace
+
+import pytest
+
+from littlepay.api.products import ProductResponse
+from littlepay.commands import RESULT_SUCCESS
+from littlepay.commands.products import products
+
+PRODUCT_RESPONSES = [
+    ProductResponse("id0", "code0", "ACTIVE", "type0", "description0", "participant123"),
+    ProductResponse("id1", "code1", "INACTIVE", "type1", "description1", "participant123"),
+    ProductResponse("id2", "code2", "EXPIRED", "type2", "description2", "participant123"),
+    ProductResponse("id3", "code3", "EXPIRED", "type3", "description3", "participant123"),
+]
+
+
+@pytest.fixture(autouse=True)
+def mock_config(mocker):
+    mocker.patch("littlepay.commands.products.config")
+
+
+@pytest.fixture
+def mock_client(mocker):
+    client = mocker.Mock()
+    mocker.patch("littlepay.commands.products.Client.from_active_config", return_value=client)
+    return client
+
+
+@pytest.fixture(autouse=True)
+def mock_get_products(mock_client):
+    mock_client.get_products.return_value = PRODUCT_RESPONSES
+
+
+def test_products_default(mock_client, capfd):
+    res = products()
+    capture = capfd.readouterr()
+
+    assert res == RESULT_SUCCESS
+
+    mock_client.oauth.ensure_active_token.assert_called_once()
+    mock_client.get_products.assert_called_with(status=None)
+
+    assert "Matching products (4)" in capture.out
+    for response in PRODUCT_RESPONSES:
+        assert str(response) in capture.out
+
+
+@pytest.mark.parametrize("product_response", PRODUCT_RESPONSES)
+def test_products_product_status(mock_client, product_response, capfd):
+    args = Namespace(product_status=product_response.status)
+    res = products(args)
+    capture = capfd.readouterr()
+
+    assert res == RESULT_SUCCESS
+    mock_client.get_products.assert_called_with(status=product_response.status)
+
+    assert "Matching products" in capture.out
+
+
+@pytest.mark.parametrize("product_response", PRODUCT_RESPONSES)
+@pytest.mark.parametrize("filter_attribute", ["id", "code", "description"])
+def test_products_product_term(product_response, filter_attribute, capfd):
+    filter_value = getattr(product_response, filter_attribute)
+    args = Namespace(product_terms=[filter_value])
+    res = products(args)
+    capture = capfd.readouterr()
+
+    assert res == RESULT_SUCCESS
+
+    assert "Matching products (1)" in capture.out
+    for response in PRODUCT_RESPONSES:
+        if response == product_response:
+            assert str(response) in capture.out
+        else:
+            assert str(response) not in capture.out
+
+
+def test_products_product_term_multiple(capfd):
+    terms = [PRODUCT_RESPONSES[0].id, PRODUCT_RESPONSES[1].code, PRODUCT_RESPONSES[2].description]
+    args = Namespace(product_terms=terms)
+    res = products(args)
+    capture = capfd.readouterr()
+
+    assert res == RESULT_SUCCESS
+
+    assert "Matching products (3)" in capture.out
+    for response in PRODUCT_RESPONSES:
+        if PRODUCT_RESPONSES.index(response) in [0, 1, 2]:
+            assert str(response) in capture.out
+        else:
+            assert str(response) not in capture.out

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,6 +118,12 @@ def mock_commands_groups(mock_module_name):
 
 
 @pytest.fixture
+def mock_commands_products(mock_module_name):
+    """Fixture returns a function that patches commands.products in a given module."""
+    return mock_module_name("products")
+
+
+@pytest.fixture
 def mock_commands_switch(mock_module_name):
     """Fixture returns a function that patches commands.switch in a given module."""
     return mock_module_name("switch")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -121,3 +121,16 @@ def mock_commands_groups(mock_module_name):
 def mock_commands_switch(mock_module_name):
     """Fixture returns a function that patches commands.switch in a given module."""
     return mock_module_name("switch")
+
+
+@pytest.fixture
+def mock_ClientProtocol_delete(mocker):
+    return mocker.patch("littlepay.api.ClientProtocol._delete", side_effect=lambda *args, **kwargs: True)
+
+
+@pytest.fixture(autouse=True)
+def mock_ClientProtocol_make_endpoint(mocker, url):
+    # patch _make_endpoint to create a endpoint for example.com
+    mocker.patch(
+        "littlepay.api.ClientProtocol._make_endpoint", side_effect=lambda *args: f"{url}/{'/'.join([a for a in args if a])}"
+    )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -105,6 +105,16 @@ def test_main_groups_create(mock_commands_groups):
     assert call_args.group_label == "label"
 
 
+def test_main_groups_link(mock_commands_groups):
+    result = main(argv=["groups", "link", "1234"])
+
+    assert result == RESULT_SUCCESS
+    mock_commands_groups.assert_called_once()
+    call_args = mock_commands_groups.call_args.args[0]
+    assert call_args.group_command == "link"
+    assert call_args.product_id == "1234"
+
+
 def test_main_groups_products(mock_commands_groups):
     result = main(argv=["groups", "products"])
 
@@ -134,6 +144,16 @@ def test_main_groups_remove_force(mock_commands_groups, argv):
     assert call_args.group_command == "remove"
     assert call_args.group_id == "1234"
     assert call_args.force is True
+
+
+def test_main_groups_unlink(mock_commands_groups):
+    result = main(argv=["groups", "unlink", "1234"])
+
+    assert result == RESULT_SUCCESS
+    mock_commands_groups.assert_called_once()
+    call_args = mock_commands_groups.call_args.args[0]
+    assert call_args.group_command == "unlink"
+    assert call_args.product_id == "1234"
 
 
 def test_main_products(mock_commands_products):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -18,6 +18,11 @@ def mock_commands_groups(mock_commands_groups):
 
 
 @pytest.fixture
+def mock_commands_products(mock_commands_products):
+    return mock_commands_products(MODULE)
+
+
+@pytest.fixture
 def mock_commands_switch(mock_commands_switch):
     return mock_commands_switch(MODULE)
 
@@ -120,6 +125,55 @@ def test_main_groups_remove_force(mock_commands_groups, argv):
     assert call_args.group_command == "remove"
     assert call_args.group_id == "1234"
     assert call_args.force is True
+
+
+def test_main_products(mock_commands_products):
+    result = main(argv=["products"])
+
+    assert result == RESULT_SUCCESS
+    mock_commands_products.assert_called_once()
+    call_args = mock_commands_products.call_args.args[0]
+    assert isinstance(call_args, Namespace)
+    assert call_args.command == "products"
+
+
+@pytest.mark.parametrize("filter_flag", ["-f", "--filter"])
+def test_main_products_filter(mock_commands_products, filter_flag):
+    result = main(argv=["products", filter_flag, "term"])
+
+    assert result == RESULT_SUCCESS
+    mock_commands_products.assert_called_once()
+    call_args = mock_commands_products.call_args.args[0]
+    assert call_args.product_terms == ["term"]
+
+
+@pytest.mark.parametrize("filter_flag", ["-f", "--filter"])
+def test_main_products_filter_multiple(mock_commands_products, filter_flag):
+    result = main(argv=["products", filter_flag, "term1", filter_flag, "term2"])
+
+    assert result == RESULT_SUCCESS
+    mock_commands_products.assert_called_once()
+    call_args = mock_commands_products.call_args.args[0]
+    assert call_args.product_terms == ["term1", "term2"]
+
+
+@pytest.mark.parametrize("status_flag", ["-s", "--status"])
+@pytest.mark.parametrize("status_value", ["ACTIVE", "INACTIVE", "EXPIRED"])
+def test_main_products_status(mock_commands_products, status_flag, status_value):
+    result = main(argv=["products", status_flag, status_value])
+
+    assert result == RESULT_SUCCESS
+    mock_commands_products.assert_called_once()
+    call_args = mock_commands_products.call_args.args[0]
+    assert call_args.product_status == status_value
+
+
+@pytest.mark.parametrize("status_flag", ["-s", "--status"])
+def test_main_products_status_unrecognized(mock_commands_products, status_flag):
+    with pytest.raises(SystemExit):
+        main(argv=["products", status_flag, "UNRECOGNIZED"])
+
+    assert mock_commands_products.call_count == 0
 
 
 @pytest.mark.parametrize("switch_type", CONFIG_TYPES)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -105,6 +105,15 @@ def test_main_groups_create(mock_commands_groups):
     assert call_args.group_label == "label"
 
 
+def test_main_groups_products(mock_commands_groups):
+    result = main(argv=["groups", "products"])
+
+    assert result == RESULT_SUCCESS
+    mock_commands_groups.assert_called_once()
+    call_args = mock_commands_groups.call_args.args[0]
+    assert call_args.group_command == "products"
+
+
 def test_main_groups_remove(mock_commands_groups):
     result = main(argv=["groups", "remove", "1234"])
 


### PR DESCRIPTION
## What this PR does

* New command `littlepay products` lists the products in the active environment
* `littlepay products --filter <term>` filters the list by product ID, code, or description
* `littlepay products [--filter <term>] link <group_id>` links one or more products to a group
* `littlepay products [--filter <term>] unlink <group_id>` unlinks one or more products from a group
* `littlepay groups [--filter <term>] products` lists products linked to one or more groups
* `littlepay groups [--filter <term>] link <product_id>` links a product to one or more groups
* `littlepay groups [--filter <term>] unlink <product_id>` unlinks a product from one or more groups

With this PR, `littlepay` can entirely replace our helper scripts in [`benefits-secrets`](https://github.com/cal-itp/benefits-secrets/tree/main/littlepay/bin/customer).