### PR TITLE
Feat(enrollment): link funding source to group

### DIFF
--- a/littlepay/api/client.py
+++ b/littlepay/api/client.py
@@ -64,7 +64,7 @@ def _json_post_credentials(client, method, uri, headers, body) -> tuple:
     return uri, headers, json_data
 
 
-class Client(CardTokenizationMixin, ProductsMixin, GroupsMixin, FundingSourcesMixin, ClientProtocol):
+class Client(FundingSourcesMixin, CardTokenizationMixin, ProductsMixin, GroupsMixin, ClientProtocol):
     """Represents an API connection to an environment."""
 
     from_active_config = staticmethod(_client_from_active_config)

--- a/littlepay/api/funding_sources.py
+++ b/littlepay/api/funding_sources.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from typing import List, Optional
 
 from littlepay.api import ClientProtocol
+from littlepay.api.groups import GroupsMixin
 
 
 @dataclass
@@ -25,7 +26,7 @@ class FundingSourceResponse:
     icc_hash: Optional[str] = None
 
 
-class FundingSourcesMixin(ClientProtocol):
+class FundingSourcesMixin(GroupsMixin, ClientProtocol):
     """Mixin implements APIs for funding sources."""
 
     FUNDING_SOURCES = "fundingsources"
@@ -38,3 +39,13 @@ class FundingSourcesMixin(ClientProtocol):
         """Return a FundingSourceResponse object from the funding source by token endpoint."""
         endpoint = self.funding_source_by_token_endpoint(card_token)
         return self._get(endpoint, FundingSourceResponse)
+
+    def concession_group_funding_source_endpoint(self, group_id: str) -> str:
+        """Endpoint for a concession group's funding sources."""
+        return self.concession_groups_endpoint(group_id, self.FUNDING_SOURCES)
+
+    def link_concession_group_funding_source(self, group_id: str, funding_source_id: str) -> dict:
+        """Link a funding source to a concession group."""
+        endpoint = self.concession_group_funding_source_endpoint(group_id)
+        data = {"id": funding_source_id}
+        return self._post(endpoint, data, dict)

--- a/littlepay/api/funding_sources.py
+++ b/littlepay/api/funding_sources.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass
 from typing import List, Optional
 
 from littlepay.api import ClientProtocol
-from littlepay.api.groups import GroupsMixin
 
 
 @dataclass
@@ -26,7 +25,7 @@ class FundingSourceResponse:
     icc_hash: Optional[str] = None
 
 
-class FundingSourcesMixin(GroupsMixin, ClientProtocol):
+class FundingSourcesMixin(ClientProtocol):
     """Mixin implements APIs for funding sources."""
 
     FUNDING_SOURCES = "fundingsources"
@@ -39,13 +38,3 @@ class FundingSourcesMixin(GroupsMixin, ClientProtocol):
         """Return a FundingSourceResponse object from the funding source by token endpoint."""
         endpoint = self.funding_source_by_token_endpoint(card_token)
         return self._get(endpoint, FundingSourceResponse)
-
-    def concession_group_funding_source_endpoint(self, group_id: str) -> str:
-        """Endpoint for a concession group's funding sources."""
-        return self.concession_groups_endpoint(group_id, self.FUNDING_SOURCES)
-
-    def link_concession_group_funding_source(self, group_id: str, funding_source_id: str) -> dict:
-        """Link a funding source to a concession group."""
-        endpoint = self.concession_group_funding_source_endpoint(group_id)
-        data = {"id": funding_source_id}
-        return self._post(endpoint, data, dict)

--- a/littlepay/api/groups.py
+++ b/littlepay/api/groups.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from typing import Generator
 
 from littlepay.api import ClientProtocol
+from littlepay.api.funding_sources import FundingSourcesMixin
 
 
 @dataclass
@@ -20,6 +21,10 @@ class GroupsMixin(ClientProtocol):
         """Endpoint for concession groups. Optionally provide a group_id for a group-specific endpoint."""
         return self._make_endpoint(self.CONCESSION_GROUPS, group_id, *parts)
 
+    def concession_group_funding_source_endpoint(self, group_id: str) -> str:
+        """Endpoint for a concession group's funding sources."""
+        return self.concession_groups_endpoint(group_id, FundingSourcesMixin.FUNDING_SOURCES)
+
     def create_concession_group(self, group_label: str) -> dict:
         """Create a new concession group."""
         endpoint = self.concession_groups_endpoint()
@@ -36,3 +41,9 @@ class GroupsMixin(ClientProtocol):
         """Remove an existing concession group."""
         endpoint = self.concession_groups_endpoint(group_id)
         return self._delete(endpoint)
+
+    def link_concession_group_funding_source(self, group_id: str, funding_source_id: str) -> dict:
+        """Link a funding source to a concession group."""
+        endpoint = self.concession_group_funding_source_endpoint(group_id)
+        data = {"id": funding_source_id}
+        return self._post(endpoint, data, dict)

--- a/tests/api/test_funding_sources.py
+++ b/tests/api/test_funding_sources.py
@@ -20,6 +20,12 @@ def mock_ClientProtocol_get_FundingResource(mocker):
     return mocker.patch("littlepay.api.ClientProtocol._get", return_value=funding_source)
 
 
+@pytest.fixture
+def mock_ClientProtocol_post(mocker):
+    response = {"status_code": 201}
+    return mocker.patch("littlepay.api.ClientProtocol._post", side_effect=lambda *args, **kwargs: response)
+
+
 def test_FundingSourcesMixin_funding_sources_by_token_endpoint(url):
     client = FundingSourcesMixin()
 
@@ -42,3 +48,12 @@ def test_FundingSourcesMixin_get_funding_source_by_token(mock_ClientProtocol_get
         client.funding_source_by_token_endpoint(card_token), FundingSourceResponse
     )
     assert isinstance(result, FundingSourceResponse)
+
+
+def test_FundingSourcesMixin_link_concession_group_product(mock_ClientProtocol_post):
+    client = FundingSourcesMixin()
+    result = client.link_concession_group_funding_source("group-1234", "funding-source-1234")
+
+    endpoint = client.concession_group_funding_source_endpoint("group-1234")
+    mock_ClientProtocol_post.assert_called_once_with(endpoint, {"id": "funding-source-1234"}, dict)
+    assert result == {"status_code": 201}

--- a/tests/api/test_funding_sources.py
+++ b/tests/api/test_funding_sources.py
@@ -20,10 +20,16 @@ def mock_ClientProtocol_get_FundingResource(mocker):
     return mocker.patch("littlepay.api.ClientProtocol._get", return_value=funding_source)
 
 
-def test_FundingSourcesMixin_concession_groups_fundingsources_endpoint(url):
+def test_FundingSourcesMixin_funding_sources_by_token_endpoint(url):
     client = FundingSourcesMixin()
 
     assert client.funding_source_by_token_endpoint("abc_token") == f"{url}/fundingsources/bytoken/abc_token"
+
+
+def test_FundingSourcesMixin_concession_groups_funding_sources_endpoint(url):
+    client = FundingSourcesMixin()
+
+    assert client.concession_group_funding_source_endpoint("1234") == f"{url}/concession_groups/1234/fundingsources"
 
 
 def test_FundingSourcesMixin_get_funding_source_by_token(mock_ClientProtocol_get_FundingResource):

--- a/tests/api/test_funding_sources.py
+++ b/tests/api/test_funding_sources.py
@@ -20,22 +20,10 @@ def mock_ClientProtocol_get_FundingResource(mocker):
     return mocker.patch("littlepay.api.ClientProtocol._get", return_value=funding_source)
 
 
-@pytest.fixture
-def mock_ClientProtocol_post(mocker):
-    response = {"status_code": 201}
-    return mocker.patch("littlepay.api.ClientProtocol._post", side_effect=lambda *args, **kwargs: response)
-
-
 def test_FundingSourcesMixin_funding_sources_by_token_endpoint(url):
     client = FundingSourcesMixin()
 
     assert client.funding_source_by_token_endpoint("abc_token") == f"{url}/fundingsources/bytoken/abc_token"
-
-
-def test_FundingSourcesMixin_concession_groups_funding_sources_endpoint(url):
-    client = FundingSourcesMixin()
-
-    assert client.concession_group_funding_source_endpoint("1234") == f"{url}/concession_groups/1234/fundingsources"
 
 
 def test_FundingSourcesMixin_get_funding_source_by_token(mock_ClientProtocol_get_FundingResource):
@@ -48,12 +36,3 @@ def test_FundingSourcesMixin_get_funding_source_by_token(mock_ClientProtocol_get
         client.funding_source_by_token_endpoint(card_token), FundingSourceResponse
     )
     assert isinstance(result, FundingSourceResponse)
-
-
-def test_FundingSourcesMixin_link_concession_group_product(mock_ClientProtocol_post):
-    client = FundingSourcesMixin()
-    result = client.link_concession_group_funding_source("group-1234", "funding-source-1234")
-
-    endpoint = client.concession_group_funding_source_endpoint("group-1234")
-    mock_ClientProtocol_post.assert_called_once_with(endpoint, {"id": "funding-source-1234"}, dict)
-    assert result == {"status_code": 201}


### PR DESCRIPTION
Part of #10 

This PR adds a method to `Client` to link a funding source to a group using their IDs.