### PR TITLE
CI: git scrape groups and products

### DIFF
--- a/.github/workflows/scrape.yml
+++ b/.github/workflows/scrape.yml
@@ -1,0 +1,60 @@
+name: Scape data for active agencies
+
+on:
+  workflow_dispatch:
+  schedule:
+    # every day at 6am UTC, 10-11pm Pacific
+    - cron: "0 6 * * *"
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        participant: [mst, sacrt, sbmtd]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install the littlepay library
+        run: |
+          python3 -m pip install --upgrade pip
+          pip install -e .
+
+      - name: Create config file and set participant
+        # the LITTLEPAY_CONFIG secret only contains configuration for the prod env
+        # the prod env is already activated, with no participant yet activated
+        run: |
+          cat > .config/scrape.yaml <<- EOM
+          ${{ secrets.LITTLEPAY_CONFIG }}
+          EOM
+          littlepay config .config/scrape.yaml
+          littlepay switch participant ${{ matrix.participant }}
+
+      - name: Get groups
+        run: littlepay groups --csv > data/${{ matrix.participant }}_groups.csv
+
+      - name: Get products
+        run: littlepay products --csv > data/${{ matrix.participant }}_products.csv
+
+      - name: Get group<>product associations
+        run: littlepay groups products --csv > data/${{ matrix.participant }}_linked_groups_products.csv
+
+      - name: Check for modified data files
+        id: git-modified
+        run: echo modified=$(if [ -n "$(git status --porcelain)" ]; then echo "true"; else echo "false"; fi) >> "$GITHUB_OUTPUT"
+
+      - name: Commit modified data files
+        if: steps.git-modified.outputs.modified == 'true'
+        run: |
+          git config user.name "Cal-ITP Bot"
+          git config user.email "bot@calitp.org"
+          git add data/
+          timestamp=$(date -u)
+          git commit -m "chore(data): update ${{ matrix.participant }} at ${timestamp}" || exit 0
+          git push

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ littlepay switch participant <participant_id>
 
 ```console
 $ littlepay groups -h
-usage: littlepay groups [-h] [-f GROUP_TERMS] {create,link,products,remove,unlink} ...
+usage: littlepay groups [-h] [-f GROUP_TERMS] [--csv] {create,link,products,remove,unlink} ...
 
 positional arguments:
   {create,link,products,remove,unlink}
@@ -128,6 +128,7 @@ options:
   -h, --help            show this help message and exit
   -f GROUP_TERMS, --filter GROUP_TERMS
                         Filter for groups with matching group ID or label
+  --csv                 Output results in simple CSV format
 ```
 
 ### List existing groups

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ littlepay groups remove --force <group_id>
 
 ```console
 $ littlepay products -h
-usage: littlepay products [-h] [-f PRODUCT_TERMS] [-s {ACTIVE,INACTIVE,EXPIRED}] {link,unlink} ...
+usage: littlepay products [-h] [-f PRODUCT_TERMS] [-s {ACTIVE,INACTIVE,EXPIRED}] [--csv] {link,unlink} ...
 
 positional arguments:
   {link,unlink}
@@ -188,6 +188,7 @@ options:
                         Filter for products with matching product ID, code, or description
   -s {ACTIVE,INACTIVE,EXPIRED}, --status {ACTIVE,INACTIVE,EXPIRED}
                         Filter for products with matching status
+  --csv                 Output results in simple CSV format
 ```
 
 ### List existing products

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,4 @@
+# data
+
+This directory stores the current state of Products and Groups for agencies using
+Littlepay supported by Cal-ITP and the [Benefits](https://github.com/cal-itp/benefits) team.

--- a/littlepay/api/groups.py
+++ b/littlepay/api/groups.py
@@ -13,7 +13,9 @@ class GroupResponse:
 
     def csv(self) -> str:
         """Get a CSV str representation of values for this GroupResponse."""
-        return ",".join(vars(self).values())
+        # wrap values containing commas in double quotes
+        vals = [f'"{v}"' if "," in v else v for v in vars(self).values()]
+        return ",".join(vals)
 
     @staticmethod
     def csv_header() -> str:

--- a/littlepay/api/groups.py
+++ b/littlepay/api/groups.py
@@ -11,6 +11,16 @@ class GroupResponse:
     label: str
     participant_id: str
 
+    def csv(self) -> str:
+        """Get a CSV str representation of values for this GroupResponse."""
+        return ",".join(vars(self).values())
+
+    @staticmethod
+    def csv_header() -> str:
+        """Get a CSV str header of attributes for GroupResponse."""
+        instance = GroupResponse("", "", "")
+        return ",".join(vars(instance).keys())
+
 
 class GroupsMixin(ClientProtocol):
     """Mixin implements APIs for concession groups."""

--- a/littlepay/api/products.py
+++ b/littlepay/api/products.py
@@ -14,6 +14,16 @@ class ProductResponse:
     description: str
     participant_id: str
 
+    def csv(self) -> str:
+        """Get a CSV str representation of values for this ProductResponse."""
+        return ",".join(vars(self).values())
+
+    @staticmethod
+    def csv_header() -> str:
+        """Get a CSV str header of attributes for ProductResponse."""
+        instance = ProductResponse("", "", "", "", "", "")
+        return ",".join(vars(instance).keys())
+
 
 class ProductsMixin(GroupsMixin, ClientProtocol):
     """Mixin implements APIs for products."""

--- a/littlepay/api/products.py
+++ b/littlepay/api/products.py
@@ -16,7 +16,9 @@ class ProductResponse:
 
     def csv(self) -> str:
         """Get a CSV str representation of values for this ProductResponse."""
-        return ",".join(vars(self).values())
+        # wrap values containing commas in double quotes
+        vals = [f'"{v}"' if "," in v else v for v in vars(self).values()]
+        return ",".join(vals)
 
     @staticmethod
     def csv_header() -> str:

--- a/littlepay/commands/groups.py
+++ b/littlepay/commands/groups.py
@@ -46,11 +46,9 @@ def groups(args: Namespace = None) -> int:
 
     groups = list(groups)
     if csv_output and command != "products":
-        # print the CSV header for groups using an empty GroupResponse to get attribute keys
-        group_attrs = vars(GroupResponse("", "", "")).keys()
-        print(",".join(group_attrs))
+        print(GroupResponse.csv_header())
     elif csv_output and command == "products":
-        # print the CSV header for group<>product associations
+        # print a custom CSV header for group<>product associations
         print("group_id,product_id,participant_id")
     else:
         print_active_message(config, f"👥 Matching groups ({len(groups)})")
@@ -68,8 +66,7 @@ def groups(args: Namespace = None) -> int:
                 else:
                     print(" ", product)
         elif csv_output:
-            group_vals = vars(group).values()
-            print(",".join(group_vals))
+            print(group.csv())
 
     return RESULT_SUCCESS if return_code == RESULT_SUCCESS else RESULT_FAILURE
 

--- a/littlepay/commands/groups.py
+++ b/littlepay/commands/groups.py
@@ -3,6 +3,7 @@ from argparse import Namespace
 from requests import HTTPError
 
 from littlepay.api.client import Client
+from littlepay.api.groups import GroupResponse
 from littlepay.commands import RESULT_FAILURE, RESULT_SUCCESS, print_active_message
 from littlepay.config import Config
 
@@ -14,6 +15,8 @@ def groups(args: Namespace = None) -> int:
     client = Client.from_active_config(config)
     client.oauth.ensure_active_token(client.token)
     config.active_token = client.token
+
+    csv_output = hasattr(args, "csv") and args.csv
 
     if hasattr(args, "group_command"):
         command = args.group_command
@@ -42,15 +45,31 @@ def groups(args: Namespace = None) -> int:
             return_code += unlink_product(client, group.id, args.product_id)
 
     groups = list(groups)
-    print_active_message(config, f"👥 Matching groups ({len(groups)})")
+    if csv_output and command != "products":
+        # print the CSV header for groups using an empty GroupResponse to get attribute keys
+        group_attrs = vars(GroupResponse("", "", "")).keys()
+        print(",".join(group_attrs))
+    elif csv_output and command == "products":
+        # print the CSV header for group<>product associations
+        print("group_id,product_id,participant_id")
+    else:
+        print_active_message(config, f"👥 Matching groups ({len(groups)})")
 
     for group in groups:
-        print(group)
+        if not csv_output:
+            print(group)
         if command == "products":
             products = list(client.get_concession_group_products(group.id))
-            print(f"  🛒 Linked products ({len(products)})")
+            if not csv_output:
+                print(f"  🛒 Linked products ({len(products)})")
             for product in products:
-                print(" ", product)
+                if csv_output:
+                    print(f"{group.id},{product.id},{group.participant_id}")
+                else:
+                    print(" ", product)
+        elif csv_output:
+            group_vals = vars(group).values()
+            print(",".join(group_vals))
 
     return RESULT_SUCCESS if return_code == RESULT_SUCCESS else RESULT_FAILURE
 

--- a/littlepay/commands/products.py
+++ b/littlepay/commands/products.py
@@ -1,6 +1,7 @@
 from argparse import Namespace
 
 from littlepay.api.client import Client
+from littlepay.api.products import ProductResponse
 from littlepay.commands import RESULT_FAILURE, RESULT_SUCCESS, print_active_message
 from littlepay.commands.groups import link_product, unlink_product
 from littlepay.config import Config
@@ -13,6 +14,8 @@ def products(args: Namespace = None) -> int:
     client = Client.from_active_config(config)
     client.oauth.ensure_active_token(client.token)
     config.active_token = client.token
+
+    csv_output = hasattr(args, "csv") and args.csv
 
     if hasattr(args, "product_command"):
         command = args.product_command
@@ -36,10 +39,19 @@ def products(args: Namespace = None) -> int:
         )
 
     products = list(products)
-    print_active_message(config, f"🛒 Matching products ({len(products)})")
+    if csv_output:
+        # print the CSV header for products using an empty ProductResponse to get attribute keys
+        product_attrs = vars(ProductResponse("", "", "", "", "", "")).keys()
+        print(",".join(product_attrs))
+    else:
+        print_active_message(config, f"🛒 Matching products ({len(products)})")
 
     for product in products:
-        print(product)
+        if csv_output:
+            product_vals = vars(product).values()
+            print(",".join(product_vals))
+        else:
+            print(product)
 
     if command == "link":
         for product in products:

--- a/littlepay/commands/products.py
+++ b/littlepay/commands/products.py
@@ -40,16 +40,13 @@ def products(args: Namespace = None) -> int:
 
     products = list(products)
     if csv_output:
-        # print the CSV header for products using an empty ProductResponse to get attribute keys
-        product_attrs = vars(ProductResponse("", "", "", "", "", "")).keys()
-        print(",".join(product_attrs))
+        print(ProductResponse.csv_header())
     else:
         print_active_message(config, f"🛒 Matching products ({len(products)})")
 
     for product in products:
         if csv_output:
-            product_vals = vars(product).values()
-            print(",".join(product_vals))
+            print(product.csv())
         else:
             print(product)
 

--- a/littlepay/main.py
+++ b/littlepay/main.py
@@ -1,5 +1,5 @@
-from argparse import _SubParsersAction, ArgumentParser
 import sys
+from argparse import ArgumentParser, _SubParsersAction
 
 from littlepay import __version__ as version
 from littlepay.commands.configure import configure
@@ -51,6 +51,9 @@ def main(argv=None):
     groups_parser.add_argument(
         "-f", "--filter", help="Filter for groups with matching group ID or label", dest="group_terms", action="append"
     )
+    groups_parser.add_argument(
+        "--csv", action="store_true", default=False, help="Output results in simple CSV format", dest="csv"
+    )
 
     groups_commands = groups_parser.add_subparsers(dest="group_command", required=False)
 
@@ -60,7 +63,10 @@ def main(argv=None):
     groups_link = _subcmd(groups_commands, "link", help="Link one or more concession groups to a product")
     groups_link.add_argument("product_id", help="The ID of the product to link to")
 
-    _subcmd(groups_commands, "products", help="List products for one or more concession groups")
+    groups_products = _subcmd(groups_commands, "products", help="List products for one or more concession groups")
+    groups_products.add_argument(
+        "--csv", action="store_true", default=False, help="Output results in simple CSV format", dest="csv"
+    )
 
     groups_remove = _subcmd(groups_commands, "remove", help="Remove an existing concession group")
     groups_remove.add_argument("--force", action="store_true", default=False, help="Don't ask for confirmation before removal")

--- a/littlepay/main.py
+++ b/littlepay/main.py
@@ -91,6 +91,9 @@ def main(argv=None):
         choices=["ACTIVE", "INACTIVE", "EXPIRED"],
         dest="product_status",
     )
+    products_parser.add_argument(
+        "--csv", action="store_true", default=False, help="Output results in simple CSV format", dest="csv"
+    )
 
     products_commands = products_parser.add_subparsers(dest="product_command", required=False)
 

--- a/tests/api/test_groups.py
+++ b/tests/api/test_groups.py
@@ -27,6 +27,15 @@ def mock_ClientProtocol_post_link_concession_group_funding_source(mocker):
     return mocker.patch("littlepay.api.ClientProtocol._post", side_effect=lambda *args, **kwargs: response)
 
 
+def test_GroupResponse_csv():
+    group = GroupResponse("id", "label", "participant")
+    assert group.csv() == "id,label,participant"
+
+
+def test_GroupResponse_csv_header():
+    assert GroupResponse.csv_header() == "id,label,participant_id"
+
+
 def test_GroupsMixin_concession_groups_endpoint(url):
     client = GroupsMixin()
 

--- a/tests/api/test_groups.py
+++ b/tests/api/test_groups.py
@@ -31,6 +31,9 @@ def test_GroupResponse_csv():
     group = GroupResponse("id", "label", "participant")
     assert group.csv() == "id,label,participant"
 
+    group = GroupResponse("id", "label, with, commas", "participant")
+    assert group.csv() == 'id,"label, with, commas",participant'
+
 
 def test_GroupResponse_csv_header():
     assert GroupResponse.csv_header() == "id,label,participant_id"

--- a/tests/api/test_products.py
+++ b/tests/api/test_products.py
@@ -45,6 +45,15 @@ def mock_ClientProtocol_post(mocker):
     return mocker.patch("littlepay.api.ClientProtocol._post", side_effect=lambda *args, **kwargs: response)
 
 
+def test_ProductResponse_csv():
+    group = ProductResponse("id", "code", "status", "type", "description", "participant")
+    assert group.csv() == "id,code,status,type,description,participant"
+
+
+def test_ProductResponse_csv_header():
+    assert ProductResponse.csv_header() == "id,code,status,type,description,participant_id"
+
+
 def test_ProductsMixin_concession_groups_products_endpoint(url):
     client = ProductsMixin()
 

--- a/tests/api/test_products.py
+++ b/tests/api/test_products.py
@@ -46,8 +46,11 @@ def mock_ClientProtocol_post(mocker):
 
 
 def test_ProductResponse_csv():
-    group = ProductResponse("id", "code", "status", "type", "description", "participant")
-    assert group.csv() == "id,code,status,type,description,participant"
+    product = ProductResponse("id", "code", "status", "type", "description", "participant")
+    assert product.csv() == "id,code,status,type,description,participant"
+
+    product = ProductResponse("id", "code", "status", "type", "description, with, commas", "participant")
+    assert product.csv() == 'id,code,status,type,"description, with, commas",participant'
 
 
 def test_ProductResponse_csv_header():

--- a/tests/commands/test_groups.py
+++ b/tests/commands/test_groups.py
@@ -65,12 +65,10 @@ def test_groups_csv(mock_client, capfd):
 
     assert "Matching groups (3)" not in capture.out
 
-    group_attrs = vars(GroupResponse("", "", "")).keys()
-    assert ",".join(group_attrs) in capture.out
+    assert GroupResponse.csv_header() in capture.out
 
     for response in GROUP_RESPONSES:
-        group_vals = vars(response).values()
-        assert ",".join(group_vals) in capture.out
+        assert response.csv() in capture.out
         assert str(response) not in capture.out
 
 

--- a/tests/commands/test_groups.py
+++ b/tests/commands/test_groups.py
@@ -54,6 +54,26 @@ def test_groups_default(mock_client, capfd):
         assert str(response) in capture.out
 
 
+def test_groups_csv(mock_client, capfd):
+    args = Namespace(csv=True)
+    res = groups(args)
+    capture = capfd.readouterr()
+
+    assert res == RESULT_SUCCESS
+
+    mock_client.oauth.ensure_active_token.assert_called_once()
+
+    assert "Matching groups (3)" not in capture.out
+
+    group_attrs = vars(GroupResponse("", "", "")).keys()
+    assert ",".join(group_attrs) in capture.out
+
+    for response in GROUP_RESPONSES:
+        group_vals = vars(response).values()
+        assert ",".join(group_vals) in capture.out
+        assert str(response) not in capture.out
+
+
 @pytest.mark.parametrize("group_response", GROUP_RESPONSES)
 @pytest.mark.parametrize("filter_attribute", ["id", "label"])
 def test_groups_group_terms(group_response, filter_attribute, capfd):
@@ -159,6 +179,29 @@ def test_groups_group_command__products(mock_client, capfd):
             assert str(product) in capture.out
         else:
             assert str(product) not in capture.out
+
+
+def test_groups_group_command__products_csv(mock_client, capfd):
+    # fake a generator for a single item
+    mock_client.get_concession_group_products.return_value = (p for p in PRODUCT_RESPONSES if PRODUCT_RESPONSES.index(p) == 0)
+
+    args = Namespace(group_command="products", group_id="1234", csv=True)
+    res = groups(args)
+    capture = capfd.readouterr()
+
+    mock_client.get_concession_group_products.call_count == len(GROUP_RESPONSES)
+
+    assert res == RESULT_SUCCESS
+    assert "Linked products (1)" not in capture.out
+    assert "group_id,product_id,participant_id" in capture.out
+
+    for group in GROUP_RESPONSES:
+        for product in PRODUCT_RESPONSES:
+            assert str(product) not in capture.out
+            if GROUP_RESPONSES.index(group) == 0 and PRODUCT_RESPONSES.index(product) == 0:
+                assert f"{group.id},{product.id},{group.participant_id}" in capture.out
+            else:
+                assert f"{group.id},{product.id},{group.participant_id}" not in capture.out
 
 
 @pytest.mark.parametrize("sample_input", ["y", "Y", "yes", "Yes", "YES"])

--- a/tests/commands/test_products.py
+++ b/tests/commands/test_products.py
@@ -57,12 +57,10 @@ def test_products_csv(mock_client, capfd):
 
     assert "Matching products (4)" not in capture.out
 
-    product_attrs = vars(ProductResponse("", "", "", "", "", "")).keys()
-    assert ",".join(product_attrs) in capture.out
+    assert ProductResponse.csv_header() in capture.out
 
     for response in PRODUCT_RESPONSES:
-        product_vals = vars(response).values()
-        assert ",".join(product_vals) in capture.out
+        assert response.csv() in capture.out
         assert str(response) not in capture.out
 
 

--- a/tests/commands/test_products.py
+++ b/tests/commands/test_products.py
@@ -45,6 +45,27 @@ def test_products_default(mock_client, capfd):
         assert str(response) in capture.out
 
 
+def test_products_csv(mock_client, capfd):
+    args = Namespace(csv=True)
+    res = products(args)
+    capture = capfd.readouterr()
+
+    assert res == RESULT_SUCCESS
+
+    mock_client.oauth.ensure_active_token.assert_called_once()
+    mock_client.get_products.assert_called_with(status=None)
+
+    assert "Matching products (4)" not in capture.out
+
+    product_attrs = vars(ProductResponse("", "", "", "", "", "")).keys()
+    assert ",".join(product_attrs) in capture.out
+
+    for response in PRODUCT_RESPONSES:
+        product_vals = vars(response).values()
+        assert ",".join(product_vals) in capture.out
+        assert str(response) not in capture.out
+
+
 def test_products_product_command__link(mock_client, capfd):
     args = Namespace(product_command="link", group_id="1234")
     res = products(args)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -75,6 +75,17 @@ def test_main_groups(mock_commands_groups):
     assert call_args.command == "groups"
 
 
+def test_main_groups_csv(mock_commands_groups):
+    result = main(argv=["groups", "--csv"])
+
+    assert result == RESULT_SUCCESS
+    mock_commands_groups.assert_called_once()
+    call_args = mock_commands_groups.call_args.args[0]
+    assert isinstance(call_args, Namespace)
+    assert call_args.command == "groups"
+    assert call_args.csv is True
+
+
 @pytest.mark.parametrize("filter_flag", ["-f", "--filter"])
 def test_main_groups_filter(mock_commands_groups, filter_flag):
     result = main(argv=["groups", filter_flag, "term"])
@@ -122,6 +133,16 @@ def test_main_groups_products(mock_commands_groups):
     mock_commands_groups.assert_called_once()
     call_args = mock_commands_groups.call_args.args[0]
     assert call_args.group_command == "products"
+
+
+def test_main_groups_products_csv(mock_commands_groups):
+    result = main(argv=["groups", "products", "--csv"])
+
+    assert result == RESULT_SUCCESS
+    mock_commands_groups.assert_called_once()
+    call_args = mock_commands_groups.call_args.args[0]
+    assert call_args.group_command == "products"
+    assert call_args.csv is True
 
 
 def test_main_groups_remove(mock_commands_groups):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -187,6 +187,17 @@ def test_main_products(mock_commands_products):
     assert call_args.command == "products"
 
 
+def test_main_products_csv(mock_commands_products):
+    result = main(argv=["products", "--csv"])
+
+    assert result == RESULT_SUCCESS
+    mock_commands_products.assert_called_once()
+    call_args = mock_commands_products.call_args.args[0]
+    assert isinstance(call_args, Namespace)
+    assert call_args.command == "products"
+    assert call_args.csv is True
+
+
 @pytest.mark.parametrize("filter_flag", ["-f", "--filter"])
 def test_main_products_filter(mock_commands_products, filter_flag):
     result = main(argv=["products", filter_flag, "term"])


### PR DESCRIPTION
Closes #18 

Adds a new flag `--csv` to the `groups` and `products` commands, which formats the output from those commands (i.e. the list of groups/products) into simple CSV rather than the default Python representation.