### PR TITLE
Fix: don't return error with no participant

### DIFF
--- a/littlepay/commands/configure.py
+++ b/littlepay/commands/configure.py
@@ -23,8 +23,8 @@ def configure(config_path: str | Path = None) -> int:
     print(f"Participants: {', '.join(config.participants.keys())}")
 
     if config.active_participant_id == "":
-        print(f"❌ Active: {config.active_env_name}, [no participant]")
-        return RESULT_FAILURE
+        print(f"❓ Active: {config.active_env_name}, [no participant]")
+        return RESULT_SUCCESS
 
     try:
         credentials = config.active_credentials

--- a/tests/commands/test_configure.py
+++ b/tests/commands/test_configure.py
@@ -27,7 +27,7 @@ def test_configure(mocker, custom_config_file, capfd):
     res = configure(custom_config_file)
     capture = capfd.readouterr()
 
-    assert res == RESULT_FAILURE
+    assert res == RESULT_SUCCESS
     assert custom_config_file.exists()
     assert "Config:" in capture.out
     assert "Envs:" in capture.out
@@ -43,7 +43,7 @@ def test_configure_default(mock_Config, capfd):
     res = configure()
     capture = capfd.readouterr()
 
-    assert res == RESULT_FAILURE
+    assert res == RESULT_SUCCESS
     assert "Config:" in capture.out
     assert "Envs:" in capture.out
     assert "Participants:" in capture.out

--- a/tests/test_littlepay.py
+++ b/tests/test_littlepay.py
@@ -3,7 +3,7 @@ import subprocess
 
 import pytest
 
-from littlepay.commands import RESULT_FAILURE
+from littlepay.commands import RESULT_SUCCESS
 from littlepay.config import _get_current_path, _update_current_path
 from tests.conftest import CUSTOM_CONFIG_FILE
 
@@ -37,7 +37,7 @@ def test_littlepay(capfd):
     assert "Envs:" in capture.out
     assert "Participants:" in capture.out
     assert "Active:" in capture.out
-    assert res == RESULT_FAILURE
+    assert res == RESULT_SUCCESS
 
 
 def test_config(capfd):
@@ -48,4 +48,4 @@ def test_config(capfd):
     assert "Envs:" in capture.out
     assert "Participants:" in capture.out
     assert "Active:" in capture.out
-    assert res == RESULT_FAILURE
+    assert res == RESULT_SUCCESS


### PR DESCRIPTION
`littlepay` and `littlepay config` shouldn't return an error when no participant is selected; this doesn't necessarily indicate a problem, just that the configuration has not been `switch`ed to a given participant.

This PR updates the message and returns `RESULT_SUCCESS`.

Especially useful in automated processes that may switch multiple times a la #19, e.g. to avoid [this failure in the workflow run](https://github.com/cal-itp/littlepay/actions/runs/8057179199/job/22007749080#step:4:35)