### PR TITLE
Refactor(cli): provide a more helpful error when no active participant

### DIFF
--- a/littlepay/config.py
+++ b/littlepay/config.py
@@ -104,7 +104,10 @@ class Config:
         Returns (dict):
             Configuration data for the active participant.
         """
-        return self.participants[self.active_participant_id][self.active_env_name]
+        active_participant = self.participants.get(self.active_participant_id)
+        if active_participant is None:
+            raise ValueError("Missing an active participant")
+        return active_participant[self.active_env_name]
 
     @property
     def active_credentials(self) -> dict:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -205,6 +205,15 @@ def test_Config_active_participant():
     assert config.active_participant == "the participant config"
 
 
+def test_Config_active_participant_missing():
+    config = Config()
+    config.active = {"env": "env123"}
+    config.participants = {"participant123": {"env123": "the participant config"}}
+
+    with pytest.raises(ValueError):
+        config.active_participant
+
+
 def test_Config_active_credentials_default(mocker):
     config = Config()
     mocker.patch("littlepay.config.Config.active_participant", new_callable=mocker.PropertyMock, return_value={})


### PR DESCRIPTION
Closes #21 

This PR makes it so a more helpful error will be raised if the user runs some command that tries to use `config.active_participant` when there is no active participant.