### PR TITLE
Fix: allow `configure` to run without an active env

### DIFF
--- a/littlepay/commands/configure.py
+++ b/littlepay/commands/configure.py
@@ -22,8 +22,10 @@ def configure(config_path: str | Path = None) -> int:
     print(f"Envs: {', '.join(config.envs.keys())}")
     print(f"Participants: {', '.join(config.participants.keys())}")
 
-    if config.active_participant_id == "":
-        print(f"❓ Active: {config.active_env_name}, [no participant]")
+    if config.active_env_name == "" or config.active_participant_id == "":
+        env = config.active_env_name if config.active_env_name else "[no env]"
+        participant = config.active_participant_id if config.active_participant_id else "[no participant]"
+        print(f"❓ Active: {env}, {participant}")
         return RESULT_SUCCESS
 
     try:

--- a/littlepay/config.py
+++ b/littlepay/config.py
@@ -96,7 +96,10 @@ class Config:
         Returns (dict):
             Configuration data for the active environment.
         """
-        return self.envs[self.active_env_name]
+        active_env_name = self.active_env_name
+        if active_env_name is None:
+            raise ValueError("Missing active env")
+        return self.envs[active_env_name]
 
     @property
     def active_participant(self) -> dict:
@@ -119,8 +122,8 @@ class Config:
 
     @property
     def active_env_name(self) -> str:
-        """The active environment's name. By default, the QA environment."""
-        return self.active.get("env", ENV_QA)
+        """The active environment's name."""
+        return self.active.get("env", "")
 
     @active_env_name.setter
     def active_env_name(self, value: str):

--- a/littlepay/config.py
+++ b/littlepay/config.py
@@ -97,7 +97,7 @@ class Config:
             Configuration data for the active environment.
         """
         active_env_name = self.active_env_name
-        if active_env_name is None:
+        if not active_env_name:
             raise ValueError("Missing active env")
         return self.envs[active_env_name]
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -158,6 +158,15 @@ def test_Config_active_env():
     assert config.active_env == "the environment"
 
 
+def test_Config_active_missing():
+    config = Config()
+    config.active = {}
+    config.envs = {"qa": "qa environment"}
+
+    with pytest.raises(ValueError):
+        config.active_env
+
+
 def test_Config_active_participant_id(mocker):
     config = Config()
     config.active = {"participant": "active_participant"}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,7 +6,6 @@ import littlepay.config
 from littlepay.config import (
     DEFAULT_CONFIG,
     DEFAULT_CREDENTIALS,
-    ENV_QA,
     _get_current_path,
     _read_config,
     _write_config,
@@ -124,7 +123,7 @@ def test_Config_active_env_name_default():
     config = Config()
     config.active = {}
 
-    assert config.active_env_name == ENV_QA
+    assert config.active_env_name == ""
 
 
 def test_Config_active_env_name_update():


### PR DESCRIPTION
Closes #24 

This PR allows the `configure` command to run and set up the config path without trying to authenticate into any environment. The user can then use `littlepay switch` to set the active env and participant.

This was prompted by the recent failure in https://github.com/cal-itp/benefits/actions/runs/8155949034. The workflow correctly detected that the QA environment was down, but the failures for prod were not from any outage on prod, but rather because the `configure` command was trying to connect to QA first.