### PR TITLE
Fix: use v1 of PyPI publish action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
         run: python -m build
 
       - name: Publish to Test PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1.5
+        uses: pypa/gh-action-pypi-publish@release/v1
         if: ${{ contains(github.ref, '-rc') }}
         with:
           repository_url: https://test.pypi.org/legacy/
@@ -63,7 +63,7 @@ jobs:
           echo "PYPI_RELEASE_URL=https://test.pypi.org/project/calitp-littlepay/$version" >> "$GITHUB_OUTPUT"
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1.5
+        uses: pypa/gh-action-pypi-publish@release/v1
         if: ${{ !contains(github.ref, '-rc') }}
         with:
           print_hash: true


### PR DESCRIPTION
Follow-up to #31 

Trying to resolve an error we're seeing with publishing: https://github.com/cal-itp/littlepay/actions/runs/8269089795/job/22623537304#step:7:19

```
Warning:  It looks like you are trying to use an API token to authenticate in the package index and your token value does not start with "pypi-" as it typically should. This may cause an authentication error. Please verify that you have copied your token properly if such an error occurs.
```

and 

```
Uploading distributions to https://test.pypi.org/legacy/
INFO     dist/calitp_littlepay-2024.3.1rc2-py3-none-any.whl (25.3 KB)           
INFO     dist/calitp-littlepay-2024.3.1rc2.tar.gz (36.9 KB)                     
INFO     username set by command options                                        
INFO     password set by command options                                        
INFO     username: __token__                                                    
INFO     password: <empty>                                                      
Uploading calitp_littlepay-2024.3.1rc2-py3-none-any.whl
25l
  0% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 0.0/48.0 kB • --:-- • ?
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 48.0/48.0 kB • 00:00 • 51.1 MB/s
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 48.0/48.0 kB • 00:00 • 51.1 MB/s
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 48.0/48.0 kB • 00:00 • 51.1 MB/s
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 48.0/48.0 kB • 00:00 • 51.1 MB/s
100% ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 48.0/48.0 kB • 00:00 • 51.1 MB/s
25hINFO     Response from https://test.pypi.org/legacy/:                           
         403 Invalid or non-existent authentication information. See            
         https://test.pypi.org/help/#invalid-auth for more information.         
INFO     <html>                                                                 
          <head>                                                                
           <title>403 Invalid or non-existent authentication information. See   
         https://test.pypi.org/help/#invalid-auth for more information.</title> 
          </head>                                                               
          <body>                                                                
           <h1>403 Invalid or non-existent authentication information. See      
         https://test.pypi.org/help/#invalid-auth for more information.</h1>    
           Access was denied to this resource.<br/><br/>                        
         Invalid or non-existent authentication information. See                
         https://test.pypi.org/help/#invalid-auth for more information.         
                                                                                
                                                                                
          </body>                                                               
         </html>                                                                
ERROR    HTTPError: 403 Forbidden from https://test.pypi.org/legacy/            
         Invalid or non-existent authentication information. See                
         https://test.pypi.org/help/#invalid-auth for more information.   
```