### PR TITLE
Chore: manifest file to exclude from source build

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,11 @@
+recursive-exclude .config *
+recursive-exclude .devcontainer *
+recursive-exclude .github *
+recursive-exclude .vscode *
+recursive-exclude bin *
+recursive-exclude data *
+
+exclude .flake8
+exclude .gitignore
+exclude .pre-commit-config.yaml
+exclude compose.yaml


### PR DESCRIPTION
Excludes all files/dirs that aren't part of the Python package source, e.g. our local devcontainer files.

See more: https://setuptools.pypa.io/en/latest/userguide/miscellaneous.html#controlling-files-in-the-distribution

## Testing locally

1. In the devcontainer, `pip install build`
2. Remove any old local build artifacts e.g. `dist/`, `calitp_littlepay.egg-info/`
3. Run `python -m build`
4. View contents of `calitp-littlepay.*.tar.gz`
5. Confirm none of the excluded files/dirs are present