### PR TITLE
chore(git): add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ __pycache__
 .config/*
 !.config/README.md
 .coverage
+.DS_Store
 .pytest_cache
 *.egg-info
 dist


### PR DESCRIPTION
This small PR adds `.DS_Store` (automatically created by macOS) to the .gitignore file.