### PR TITLE
fix(devcontainer): configure git to install pre-commit

### DIFF
--- a/.devcontainer/postAttach.sh
+++ b/.devcontainer/postAttach.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 set -eu
 
+git config --global --add safe.directory /home/calitp/app
 pre-commit install --install-hooks


### PR DESCRIPTION
Following https://github.com/cal-itp/docker-python-web/pull/36 and https://github.com/cal-itp/benefits/pull/2017, this PR fixes the last issue preventing a new developer from successfully opening devcontainers related to littlepay; namely pre-commit hooks could not be installed.

See https://www.kenmuse.com/blog/avoiding-dubious-ownership-in-dev-containers/ for more details on this solution