### PR TITLE
Fix: update group funding source expiry

### DIFF
--- a/littlepay/api/groups.py
+++ b/littlepay/api/groups.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Generator
 
-from littlepay.api import ClientProtocol, ListResponse
+from littlepay.api import ClientProtocol
 from littlepay.api.funding_sources import FundingSourceDateFields, FundingSourcesMixin
 
 
@@ -100,13 +100,9 @@ class GroupsMixin(ClientProtocol):
 
         return self._post(endpoint, data, dict)
 
-    def update_concession_group_funding_source_expiry(
-        self, group_id: str, funding_source_id: str, expiry: datetime
-    ) -> GroupFundingSourceResponse:
+    def update_concession_group_funding_source_expiry(self, group_id: str, funding_source_id: str, expiry: datetime) -> dict:
         """Update the expiry of a funding source already linked to a concession group."""
         endpoint = self.concession_group_funding_source_endpoint(group_id, funding_source_id)
         data = {"expiry": self._format_expiry(expiry)}
 
-        response = self._put(endpoint, data, ListResponse)
-
-        return GroupFundingSourceResponse(**response.list[0])
+        return self._put(endpoint, data, dict)

--- a/tests/api/test_groups.py
+++ b/tests/api/test_groups.py
@@ -64,10 +64,9 @@ def mock_ClientProtocol_post_link_concession_group_funding_source(mocker):
 
 
 @pytest.fixture
-def mock_ClientProtocol_put_update_concession_group_funding_source(mocker, ListResponse_GroupFundingSources):
-    return mocker.patch(
-        "littlepay.api.ClientProtocol._put", side_effect=lambda *args, **kwargs: ListResponse_GroupFundingSources
-    )
+def mock_ClientProtocol_put_update_concession_group_funding_source(mocker):
+    response = {"status_code": 204}
+    return mocker.patch("littlepay.api.ClientProtocol._put", side_effect=lambda *args, **kwargs: response)
 
 
 def test_GroupResponse_csv():
@@ -302,7 +301,7 @@ def test_GroupsMixin_link_concession_group_funding_source_expiry(
 
 
 def test_GroupsMixin_update_concession_group_funding_source_expiry(
-    mock_ClientProtocol_put_update_concession_group_funding_source, ListResponse_GroupFundingSources, mocker
+    mock_ClientProtocol_put_update_concession_group_funding_source, mocker
 ):
     client = GroupsMixin()
     mocker.patch.object(client, "_format_expiry", return_value="formatted expiry")
@@ -311,8 +310,7 @@ def test_GroupsMixin_update_concession_group_funding_source_expiry(
 
     endpoint = client.concession_group_funding_source_endpoint("group-1234", "funding-source-1234")
     mock_ClientProtocol_put_update_concession_group_funding_source.assert_called_once_with(
-        endpoint, {"expiry": "formatted expiry"}, ListResponse
+        endpoint, {"expiry": "formatted expiry"}, dict
     )
 
-    expected = GroupFundingSourceResponse(**ListResponse_GroupFundingSources.list[0])
-    assert result == expected
+    assert result == {"status_code": 204}


### PR DESCRIPTION
This was found while testing cal-itp/benefits#2165 and is needed by that PR.

`update_concession_group_funding_source_expiry` assumed it would get a list of a `GroupFundingSource`s, but the API [documentation](https://docs.littlepay.io/reference/backoffice/tag/Products/#tag/Products/operation/UpdateConcession) says that the response will be 
```
{ "status_code": 204 }
````

and the QA environment behavior matches the documentation.