### PR TITLE
Fix: do not raise errors for unexpected fields in responses

### DIFF
--- a/littlepay/api/__init__.py
+++ b/littlepay/api/__init__.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from typing import Generator, Protocol, TypeVar
 
 from authlib.integrations.requests_client import OAuth2Session
@@ -8,12 +7,12 @@ from authlib.integrations.requests_client import OAuth2Session
 TResponse = TypeVar("TResponse")
 
 
-@dataclass
 class ListResponse:
     """An API response with list and total_count attributes."""
 
-    list: list
-    total_count: int
+    def __init__(self, list: list, total_count: int, **kwargs):
+        self.list = list
+        self.total_count = total_count
 
 
 class ClientProtocol(Protocol):

--- a/littlepay/api/funding_sources.py
+++ b/littlepay/api/funding_sources.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from datetime import datetime
 from typing import Generator, List
 
@@ -46,15 +45,10 @@ class FundingSourceResponse:
         self.icc_hash = icc_hash
 
 
-@dataclass
 class FundingSourceDateFields:
     """Implements parsing of datetime strings to Python datetime objects for funding source fields."""
 
-    created_date: datetime | None = None
-    updated_date: datetime | None = None
-    expiry_date: datetime | None = None
-
-    def __post_init__(self):
+    def __init__(self, created_date: datetime = None, updated_date: datetime = None, expiry_date: datetime = None):
         """Parses any date parameters into Python datetime objects.
 
         For @dataclasses with a generated __init__ function, this function is called automatically.
@@ -65,25 +59,37 @@ class FundingSourceDateFields:
 
         https://docs.python.org/3.11/library/datetime.html#datetime.datetime.fromisoformat
         """
-        if self.created_date:
-            self.created_date = datetime.fromisoformat(self.created_date.replace("Z", "+00:00", 1))
+        if created_date:
+            self.created_date = datetime.fromisoformat(created_date.replace("Z", "+00:00", 1))
         else:
             self.created_date = None
-        if self.updated_date:
-            self.updated_date = datetime.fromisoformat(self.updated_date.replace("Z", "+00:00", 1))
+
+        if updated_date:
+            self.updated_date = datetime.fromisoformat(updated_date.replace("Z", "+00:00", 1))
         else:
             self.updated_date = None
-        if self.expiry_date:
-            self.expiry_date = datetime.fromisoformat(self.expiry_date.replace("Z", "+00:00", 1))
+
+        if expiry_date:
+            self.expiry_date = datetime.fromisoformat(expiry_date.replace("Z", "+00:00", 1))
         else:
             self.expiry_date = None
 
 
-@dataclass(kw_only=True)
 class FundingSourceGroupResponse(FundingSourceDateFields):
-    id: str
-    group_id: str
-    label: str
+    def __init__(
+        self,
+        id: str,
+        group_id: str,
+        label: str,
+        created_date: datetime = None,
+        updated_date: datetime = None,
+        expiry_date: datetime = None,
+        **kwargs,
+    ):
+        super().__init__(created_date, updated_date, expiry_date)
+        self.id = id
+        self.group_id = group_id
+        self.label = label
 
 
 class FundingSourcesMixin(ClientProtocol):

--- a/littlepay/api/funding_sources.py
+++ b/littlepay/api/funding_sources.py
@@ -1,29 +1,49 @@
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Generator, List, Optional
+from typing import Generator, List
 
 from littlepay.api import ClientProtocol
 
 
-@dataclass
 class FundingSourceResponse:
-    id: str
-    card_first_digits: str
-    card_last_digits: str
-    card_expiry_month: str
-    card_expiry_year: str
-    card_scheme: str
-    form_factor: str
-    participant_id: str
-    is_fpan: bool
-    related_funding_sources: List[dict]
-    card_category: Optional[str] = None
-    issuer_country_code: Optional[str] = None
-    issuer_country_numeric_code: Optional[str] = None
-    replacement_funding_source: Optional[str] = None
-    token: Optional[str] = None
-    token_key_id: Optional[str] = None
-    icc_hash: Optional[str] = None
+    def __init__(
+        self,
+        id: str,
+        card_first_digits: str,
+        card_last_digits: str,
+        card_expiry_month: str,
+        card_expiry_year: str,
+        card_scheme: str,
+        form_factor: str,
+        participant_id: str,
+        is_fpan: bool,
+        related_funding_sources: List[dict],
+        card_category: str = None,
+        issuer_country_code: str = None,
+        issuer_country_numeric_code: str = None,
+        replacement_funding_source: str = None,
+        token: str = None,
+        token_key_id: str = None,
+        icc_hash: str = None,
+        **kwargs,
+    ):
+        self.id = id
+        self.card_first_digits = card_first_digits
+        self.card_last_digits = card_last_digits
+        self.card_expiry_month = card_expiry_month
+        self.card_expiry_year = card_expiry_year
+        self.card_scheme = card_scheme
+        self.form_factor = form_factor
+        self.participant_id = participant_id
+        self.is_fpan = is_fpan
+        self.related_funding_sources = related_funding_sources
+        self.card_category = card_category
+        self.issuer_country_code = issuer_country_code
+        self.issuer_country_numeric_code = issuer_country_numeric_code
+        self.replacement_funding_source = replacement_funding_source
+        self.token = token
+        self.token_key_id = token_key_id
+        self.icc_hash = icc_hash
 
 
 @dataclass

--- a/littlepay/api/groups.py
+++ b/littlepay/api/groups.py
@@ -1,4 +1,3 @@
-from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Generator
 
@@ -6,11 +5,11 @@ from littlepay.api import ClientProtocol
 from littlepay.api.funding_sources import FundingSourceDateFields, FundingSourcesMixin
 
 
-@dataclass
 class GroupResponse:
-    id: str
-    label: str
-    participant_id: str
+    def __init__(self, id: str, label: str, participant_id: str, **kwargs):
+        self.id = id
+        self.label = label
+        self.participant_id = participant_id
 
     def csv(self) -> str:
         """Get a CSV str representation of values for this GroupResponse."""

--- a/littlepay/api/groups.py
+++ b/littlepay/api/groups.py
@@ -25,9 +25,12 @@ class GroupResponse:
         return ",".join(vars(instance).keys())
 
 
-@dataclass(kw_only=True)
 class GroupFundingSourceResponse(FundingSourceDateFields):
-    id: str
+    def __init__(
+        self, id: str, created_date: datetime = None, updated_date: datetime = None, expiry_date: datetime = None, **kwargs
+    ):
+        super().__init__(created_date, updated_date, expiry_date)
+        self.id = id
 
 
 class GroupsMixin(ClientProtocol):

--- a/littlepay/api/products.py
+++ b/littlepay/api/products.py
@@ -1,18 +1,17 @@
-from dataclasses import dataclass
 from typing import Generator
 
 from littlepay.api import ClientProtocol
 from littlepay.api.groups import GroupsMixin
 
 
-@dataclass
 class ProductResponse:
-    id: str
-    code: str
-    status: str
-    type: str
-    description: str
-    participant_id: str
+    def __init__(self, id: str, code: str, status: str, type: str, description: str, participant_id: str, **kwargs):
+        self.id = id
+        self.code = code
+        self.status = status
+        self.type = type
+        self.description = description
+        self.participant_id = participant_id
 
     def csv(self) -> str:
         """Get a CSV str representation of values for this ProductResponse."""

--- a/tests/api/test_client.py
+++ b/tests/api/test_client.py
@@ -275,6 +275,11 @@ def test_Client_get_list_paging(mocker, make_client: ClientFunc, url, default_li
     assert result == [1, 2, 3, 1, 2, 3, 1, 2, 3]
 
 
+def test_ListResponse_unexpected_fields():
+    # this test will fail if any error occurs from instantiating the class
+    ListResponse(list=[1, 2, 3], total_count=3, unexpected_field="test value")
+
+
 def test_Client_make_endpoint(make_client: ClientFunc, url):
     client = make_client()
     partial = "partial/123.json"

--- a/tests/api/test_client.py
+++ b/tests/api/test_client.py
@@ -395,7 +395,7 @@ def test_Client_put_default_cls(mocker, make_client: ClientFunc, url, ListRespon
     client = make_client()
     mock_response = mocker.Mock(
         raise_for_status=mocker.Mock(return_value=False),
-        json=mocker.Mock(return_value=dataclasses.asdict(ListResponse_sample)),
+        json=mocker.Mock(return_value=ListResponse_sample.__dict__),
     )
     req_spy = mocker.patch.object(client.oauth, "put", return_value=mock_response)
 

--- a/tests/api/test_funding_sources.py
+++ b/tests/api/test_funding_sources.py
@@ -59,6 +59,23 @@ def mock_ClientProtocol_get_list_FundingSourceGroup(mocker, ListResponse_Funding
     )
 
 
+def test_FundingSourceResponse_unexpected_fields():
+    # this test will fail if any error occurs from instantiating the class
+    FundingSourceResponse(
+        id="0",
+        card_first_digits="0000",
+        card_last_digits="0000",
+        card_expiry_month="11",
+        card_expiry_year="24",
+        card_scheme="Visa",
+        form_factor="unknown",
+        participant_id="cst",
+        is_fpan=True,
+        related_funding_sources=[],
+        unexpected_field="test value",
+    )
+
+
 def test_FundingSourceDateFields(expected_expiry_str, expected_expiry):
     fields = FundingSourceDateFields(
         created_date=expected_expiry_str, updated_date=expected_expiry_str, expiry_date=expected_expiry_str
@@ -67,6 +84,11 @@ def test_FundingSourceDateFields(expected_expiry_str, expected_expiry):
     assert fields.created_date == expected_expiry
     assert fields.updated_date == expected_expiry
     assert fields.expiry_date == expected_expiry
+
+
+def test_FundingSourceGroupResponse_unexpected_fields():
+    # this test will fail if any error occurs from instantiating the class
+    FundingSourceGroupResponse(id="id", group_id="group_id", label="label", unexpected_field="test value")
 
 
 def test_FundingSourceGroupResponse_no_dates():

--- a/tests/api/test_groups.py
+++ b/tests/api/test_groups.py
@@ -69,6 +69,11 @@ def mock_ClientProtocol_put_update_concession_group_funding_source(mocker):
     return mocker.patch("littlepay.api.ClientProtocol._put", side_effect=lambda *args, **kwargs: response)
 
 
+def test_GroupResponse_unexpected_fields():
+    # this test will fail if any error occurs from instantiating the class
+    GroupResponse(id="id", label="label", participant_id="participant", unexpected_field="test value")
+
+
 def test_GroupResponse_csv():
     group = GroupResponse("id", "label", "participant")
     assert group.csv() == "id,label,participant"
@@ -79,6 +84,11 @@ def test_GroupResponse_csv():
 
 def test_GroupResponse_csv_header():
     assert GroupResponse.csv_header() == "id,label,participant_id"
+
+
+def test_GroupFundingSourceResponse_unexpected_fields():
+    # this test will fail if any error occurs from instantiating the class
+    GroupFundingSourceResponse(id="id", unexpected_field="test value")
 
 
 def test_GroupFundingSourceResponse_no_dates():

--- a/tests/api/test_products.py
+++ b/tests/api/test_products.py
@@ -45,6 +45,19 @@ def mock_ClientProtocol_post(mocker):
     return mocker.patch("littlepay.api.ClientProtocol._post", side_effect=lambda *args, **kwargs: response)
 
 
+def test_ProductResponse_unexpected_fields():
+    # this test will fail if any error occurs from instantiating the class
+    ProductResponse(
+        id="id",
+        code="code",
+        status="status",
+        type="type",
+        description="description",
+        participant_id="participant",
+        unexpected_field="test value",
+    )
+
+
 def test_ProductResponse_csv():
     product = ProductResponse("id", "code", "status", "type", "description", "participant")
     assert product.csv() == "id,code,status,type,description,participant"


### PR DESCRIPTION
Closes #66 

After going through many different resources online about making dataclasses ignore unexpected fields, my conclusion is that Python's built-in `dataclass` does not provide an easy way to do this, and any attempts to make it work would really just defeat the purpose of using a dataclass in the first place.

[Pydantic has a `dataclass`](https://docs.pydantic.dev/latest/concepts/dataclasses/#dataclass-config) that builds on top of Python's which allows you to ignore extra fields, but when I tried it out, that caused new unrelated errors due to Pydantic performing type validation.

This PR implements the simplest and most straightforward solution, which is to just use a class. This allows us to specify a `**kwargs` parameter in the `__init__` method, which is where unexpected fields will get passed into and not cause any error.