### PR TITLE
Chore: disable Pyright type-checking rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ source = ["littlepay"]
 
 [tool.pyright]
 include = ["littlepay", "tests"]
+typeCheckingMode = "off"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]


### PR DESCRIPTION
Similar to https://github.com/cal-itp/benefits/pull/2346

I ran into this while working on #67 