### PR TITLE
Fix: allow unexpected fields in responses

### DIFF
--- a/littlepay/api/__init__.py
+++ b/littlepay/api/__init__.py
@@ -1,8 +1,12 @@
 from dataclasses import dataclass
 from inspect import signature
+import logging
 from typing import Generator, Protocol, TypeVar
 
 from authlib.integrations.requests_client import OAuth2Session
+
+
+logger = logging.getLogger(__name__)
 
 
 # Generic type parameter, used to represent the result of an API call.
@@ -30,9 +34,9 @@ def from_kwargs(cls, **kwargs):
     # use the native ones to create the class ...
     instance = cls(**native_args)
 
-    # ... and add the new ones by hand
+    # ... and log any unexpected args
     for new_name, new_val in new_args.items():
-        setattr(instance, new_name, new_val)
+        logger.info(f"Ran into an unexpected arg: {new_name} = {new_val}")
 
     return instance
 

--- a/littlepay/api/client.py
+++ b/littlepay/api/client.py
@@ -127,7 +127,8 @@ class Client(FundingSourcesMixin, CardTokenizationMixin, ProductsMixin, GroupsMi
     def _get(self, endpoint: str, response_cls: TResponse, **kwargs) -> TResponse:
         response = self.oauth.get(endpoint, headers=self.headers, params=kwargs)
         response.raise_for_status()
-        return response_cls(**response.json())
+
+        return response_cls.from_kwargs(**response.json())
 
     def _get_list(self, endpoint: str, **kwargs) -> Generator[dict, None, None]:
         params = dict(page=1, per_page=100)

--- a/littlepay/api/funding_sources.py
+++ b/littlepay/api/funding_sources.py
@@ -19,6 +19,7 @@ class FundingSourceResponse:
     participant_id: str
     is_fpan: bool
     related_funding_sources: List[dict]
+    created_date: datetime | None = None
     card_category: Optional[str] = None
     issuer_country_code: Optional[str] = None
     issuer_country_numeric_code: Optional[str] = None
@@ -30,6 +31,22 @@ class FundingSourceResponse:
     @classmethod
     def from_kwargs(cls, **kwargs):
         return from_kwargs(cls, **kwargs)
+
+    def __post_init__(self):
+        """Parses any date parameters into Python datetime objects.
+
+        For @dataclasses with a generated __init__ function, this function is called automatically.
+
+        Includes a workaround for Python 3.10 where datetime.fromisoformat() can only parse the format output
+        by datetime.isoformat(), i.e. without a trailing 'Z' offset character and with UTC offset expressed
+        as +/-HH:mm
+
+        https://docs.python.org/3.11/library/datetime.html#datetime.datetime.fromisoformat
+        """
+        if self.created_date:
+            self.created_date = datetime.fromisoformat(self.created_date.replace("Z", "+00:00", 1))
+        else:
+            self.created_date = None
 
 
 @dataclass

--- a/littlepay/api/funding_sources.py
+++ b/littlepay/api/funding_sources.py
@@ -4,6 +4,8 @@ from typing import Generator, List, Optional
 
 from littlepay.api import ClientProtocol
 
+from . import from_kwargs
+
 
 @dataclass
 class FundingSourceResponse:
@@ -24,6 +26,10 @@ class FundingSourceResponse:
     token: Optional[str] = None
     token_key_id: Optional[str] = None
     icc_hash: Optional[str] = None
+
+    @classmethod
+    def from_kwargs(cls, **kwargs):
+        return from_kwargs(cls, **kwargs)
 
 
 @dataclass
@@ -64,6 +70,10 @@ class FundingSourceGroupResponse(FundingSourceDateFields):
     id: str
     group_id: str
     label: str
+
+    @classmethod
+    def from_kwargs(cls, **kwargs):
+        return from_kwargs(cls, **kwargs)
 
 
 class FundingSourcesMixin(ClientProtocol):

--- a/littlepay/api/groups.py
+++ b/littlepay/api/groups.py
@@ -2,7 +2,7 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Generator
 
-from littlepay.api import ClientProtocol
+from littlepay.api import ClientProtocol, from_kwargs
 from littlepay.api.funding_sources import FundingSourceDateFields, FundingSourcesMixin
 
 
@@ -24,10 +24,18 @@ class GroupResponse:
         instance = GroupResponse("", "", "")
         return ",".join(vars(instance).keys())
 
+    @classmethod
+    def from_kwargs(cls, **kwargs):
+        return from_kwargs(cls, **kwargs)
+
 
 @dataclass(kw_only=True)
 class GroupFundingSourceResponse(FundingSourceDateFields):
     id: str
+
+    @classmethod
+    def from_kwargs(cls, **kwargs):
+        return from_kwargs(cls, **kwargs)
 
 
 class GroupsMixin(ClientProtocol):

--- a/littlepay/api/products.py
+++ b/littlepay/api/products.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass
 from typing import Generator
 
-from littlepay.api import ClientProtocol
+from littlepay.api import ClientProtocol, from_kwargs
 from littlepay.api.groups import GroupsMixin
 
 
@@ -25,6 +25,10 @@ class ProductResponse:
         """Get a CSV str header of attributes for ProductResponse."""
         instance = ProductResponse("", "", "", "", "", "")
         return ",".join(vars(instance).keys())
+
+    @classmethod
+    def from_kwargs(cls, **kwargs):
+        return from_kwargs(cls, **kwargs)
 
 
 class ProductsMixin(GroupsMixin, ClientProtocol):

--- a/tests/api/test_client.py
+++ b/tests/api/test_client.py
@@ -8,7 +8,7 @@ from authlib.oauth2.rfc6749 import OAuth2Token
 import pytest
 from requests import HTTPError
 
-from littlepay.api import ListResponse
+from littlepay.api import ListResponse, from_kwargs
 from littlepay.api.client import _client_from_active_config, _fix_bearer_token_header, _json_post_credentials, Client
 from littlepay.config import Config
 
@@ -48,10 +48,19 @@ class SampleResponse:
     two: str
     three: int
 
+    @classmethod
+    def from_kwargs(cls, **kwargs):
+        return from_kwargs(cls, **kwargs)
+
 
 @pytest.fixture
 def SampleResponse_json():
     return {"one": "single", "two": "double", "three": 3}
+
+
+@pytest.fixture
+def SampleResponse_json_with_unexpected_field():
+    return {"one": "single", "two": "double", "three": 3, "four": "4"}
 
 
 @pytest.fixture
@@ -232,6 +241,26 @@ def test_Client_get_params(mocker, make_client: ClientFunc, url, SampleResponse_
     assert result.three == 3
 
 
+def test_Client_get_response_has_unexpected_fields(
+    mocker, make_client: ClientFunc, url, SampleResponse_json_with_unexpected_field
+):
+    client = make_client()
+    mock_response = mocker.Mock(
+        raise_for_status=mocker.Mock(return_value=False),
+        json=mocker.Mock(return_value=SampleResponse_json_with_unexpected_field),
+    )
+    req_spy = mocker.patch.object(client.oauth, "get", return_value=mock_response)
+
+    result = client._get(url, SampleResponse)
+
+    req_spy.assert_called_once_with(url, headers=client.headers, params={})
+    assert isinstance(result, SampleResponse)
+    assert result.one == "single"
+    assert result.two == "double"
+    assert result.three == 3
+    assert result.four == "4"
+
+
 def test_Client_get_error_status(mocker, make_client: ClientFunc, url):
     client = make_client()
     mock_response = mocker.Mock(raise_for_status=mocker.Mock(side_effect=HTTPError))
@@ -241,6 +270,13 @@ def test_Client_get_error_status(mocker, make_client: ClientFunc, url):
         client._get(url, SampleResponse)
 
     req_spy.assert_called_once_with(url, headers=client.headers, params={})
+
+
+def test_ListResponse_unexpected_fields():
+    response_json = {"list": [1, 2, 3], "total_count": 3, "unexpected_field": "test value"}
+
+    # this test will fail if any error occurs from instantiating the class
+    ListResponse.from_kwargs(**response_json)
 
 
 def test_Client_get_list(mocker, make_client: ClientFunc, url, default_list_params, ListResponse_sample):

--- a/tests/api/test_client.py
+++ b/tests/api/test_client.py
@@ -258,7 +258,7 @@ def test_Client_get_response_has_unexpected_fields(
     assert result.one == "single"
     assert result.two == "double"
     assert result.three == 3
-    assert result.four == "4"
+    assert not hasattr(result, "four")
 
 
 def test_Client_get_error_status(mocker, make_client: ClientFunc, url):

--- a/tests/api/test_funding_sources.py
+++ b/tests/api/test_funding_sources.py
@@ -59,6 +59,25 @@ def mock_ClientProtocol_get_list_FundingSourceGroup(mocker, ListResponse_Funding
     )
 
 
+def test_FundingSourceResponse_unexpected_fields():
+    response_json = {
+        "id": "0",
+        "card_first_digits": "0000",
+        "card_last_digits": "0000",
+        "card_expiry_month": "11",
+        "card_expiry_year": "24",
+        "card_scheme": "Visa",
+        "form_factor": "unknown",
+        "participant_id": "cst",
+        "is_fpan": True,
+        "related_funding_sources": [],
+        "unexpected_field": "test value",
+    }
+
+    # this test will fail if any error occurs from instantiating the class
+    FundingSourceResponse(**response_json)
+
+
 def test_FundingSourceDateFields(expected_expiry_str, expected_expiry):
     fields = FundingSourceDateFields(
         created_date=expected_expiry_str, updated_date=expected_expiry_str, expiry_date=expected_expiry_str
@@ -67,6 +86,13 @@ def test_FundingSourceDateFields(expected_expiry_str, expected_expiry):
     assert fields.created_date == expected_expiry
     assert fields.updated_date == expected_expiry
     assert fields.expiry_date == expected_expiry
+
+
+def test_FundingSourceGroupResponse_unexpected_fields():
+    response_json = {"id": "id", "group_id": "group_id", "label": "label", "unexpected_field": "test value"}
+
+    # this test will fail if any error occurs from instantiating the class
+    FundingSourceGroupResponse(**response_json)
 
 
 def test_FundingSourceGroupResponse_no_dates():

--- a/tests/api/test_funding_sources.py
+++ b/tests/api/test_funding_sources.py
@@ -35,7 +35,7 @@ def ListResponse_FundingSourceGroups(expected_expiry_str):
 
 
 @pytest.fixture
-def mock_ClientProtocol_get_FundingResource(mocker):
+def mock_ClientProtocol_get_FundingResource(mocker, expected_expiry_str):
     funding_source = FundingSourceResponse(
         id="0",
         card_first_digits="0000",
@@ -47,6 +47,7 @@ def mock_ClientProtocol_get_FundingResource(mocker):
         participant_id="cst",
         is_fpan=True,
         related_funding_sources=[],
+        created_date=expected_expiry_str,
     )
     return mocker.patch("littlepay.api.ClientProtocol._get", return_value=funding_source)
 
@@ -76,6 +77,43 @@ def test_FundingSourceResponse_unexpected_fields():
 
     # this test will fail if any error occurs from instantiating the class
     FundingSourceResponse.from_kwargs(**response_json)
+
+
+def test_FundingSourceResponse_no_date_field():
+    response_json = {
+        "id": "0",
+        "card_first_digits": "0000",
+        "card_last_digits": "0000",
+        "card_expiry_month": "11",
+        "card_expiry_year": "24",
+        "card_scheme": "Visa",
+        "form_factor": "unknown",
+        "participant_id": "cst",
+        "is_fpan": True,
+        "related_funding_sources": [],
+    }
+
+    funding_source = FundingSourceResponse.from_kwargs(**response_json)
+    assert funding_source.created_date is None
+
+
+def test_FundingSourceResponse_with_date_field(expected_expiry_str, expected_expiry):
+    response_json = {
+        "id": "0",
+        "card_first_digits": "0000",
+        "card_last_digits": "0000",
+        "card_expiry_month": "11",
+        "card_expiry_year": "24",
+        "card_scheme": "Visa",
+        "form_factor": "unknown",
+        "participant_id": "cst",
+        "is_fpan": True,
+        "related_funding_sources": [],
+        "created_date": expected_expiry_str,
+    }
+
+    funding_source = FundingSourceResponse.from_kwargs(**response_json)
+    assert funding_source.created_date == expected_expiry
 
 
 def test_FundingSourceDateFields(expected_expiry_str, expected_expiry):

--- a/tests/api/test_funding_sources.py
+++ b/tests/api/test_funding_sources.py
@@ -75,7 +75,7 @@ def test_FundingSourceResponse_unexpected_fields():
     }
 
     # this test will fail if any error occurs from instantiating the class
-    FundingSourceResponse(**response_json)
+    FundingSourceResponse.from_kwargs(**response_json)
 
 
 def test_FundingSourceDateFields(expected_expiry_str, expected_expiry):
@@ -92,7 +92,7 @@ def test_FundingSourceGroupResponse_unexpected_fields():
     response_json = {"id": "id", "group_id": "group_id", "label": "label", "unexpected_field": "test value"}
 
     # this test will fail if any error occurs from instantiating the class
-    FundingSourceGroupResponse(**response_json)
+    FundingSourceGroupResponse.from_kwargs(**response_json)
 
 
 def test_FundingSourceGroupResponse_no_dates():

--- a/tests/api/test_groups.py
+++ b/tests/api/test_groups.py
@@ -69,6 +69,13 @@ def mock_ClientProtocol_put_update_concession_group_funding_source(mocker):
     return mocker.patch("littlepay.api.ClientProtocol._put", side_effect=lambda *args, **kwargs: response)
 
 
+def test_GroupResponse_unexpected_fields():
+    response_json = {"id": "id", "label": "label", "participant_id": "participant", "unexpected_field": "test value"}
+
+    # this test will fail if any error occurs from instantiating the class
+    GroupResponse(**response_json)
+
+
 def test_GroupResponse_csv():
     group = GroupResponse("id", "label", "participant")
     assert group.csv() == "id,label,participant"
@@ -79,6 +86,13 @@ def test_GroupResponse_csv():
 
 def test_GroupResponse_csv_header():
     assert GroupResponse.csv_header() == "id,label,participant_id"
+
+
+def test_GroupFundingSourceResponse_unexpected_fields():
+    response_json = {"id": "id", "unexpected_field": "test value"}
+
+    # this test will fail if any error occurs from instantiating the class
+    GroupFundingSourceResponse(**response_json)
 
 
 def test_GroupFundingSourceResponse_no_dates():

--- a/tests/api/test_groups.py
+++ b/tests/api/test_groups.py
@@ -73,7 +73,7 @@ def test_GroupResponse_unexpected_fields():
     response_json = {"id": "id", "label": "label", "participant_id": "participant", "unexpected_field": "test value"}
 
     # this test will fail if any error occurs from instantiating the class
-    GroupResponse(**response_json)
+    GroupResponse.from_kwargs(**response_json)
 
 
 def test_GroupResponse_csv():
@@ -92,7 +92,7 @@ def test_GroupFundingSourceResponse_unexpected_fields():
     response_json = {"id": "id", "unexpected_field": "test value"}
 
     # this test will fail if any error occurs from instantiating the class
-    GroupFundingSourceResponse(**response_json)
+    GroupFundingSourceResponse.from_kwargs(**response_json)
 
 
 def test_GroupFundingSourceResponse_no_dates():

--- a/tests/api/test_products.py
+++ b/tests/api/test_products.py
@@ -57,7 +57,7 @@ def test_ProductResponse_unexpected_fields():
     }
 
     # this test will fail if any error occurs from instantiating the class
-    ProductResponse(**response_json)
+    ProductResponse.from_kwargs(**response_json)
 
 
 def test_ProductResponse_csv():

--- a/tests/api/test_products.py
+++ b/tests/api/test_products.py
@@ -45,6 +45,21 @@ def mock_ClientProtocol_post(mocker):
     return mocker.patch("littlepay.api.ClientProtocol._post", side_effect=lambda *args, **kwargs: response)
 
 
+def test_ProductResponse_unexpected_fields():
+    response_json = {
+        "id": "id",
+        "code": "code",
+        "status": "status",
+        "type": "type",
+        "description": "description",
+        "participant_id": "participant",
+        "unexpected_field": "test value",
+    }
+
+    # this test will fail if any error occurs from instantiating the class
+    ProductResponse(**response_json)
+
+
 def test_ProductResponse_csv():
     product = ProductResponse("id", "code", "status", "type", "description", "participant")
     assert product.csv() == "id,code,status,type,description,participant"


### PR DESCRIPTION
Closes #66 

This PR makes it so GET requests will allow unexpected fields in the response JSON. The main code changes was for `Client._get` to expect that it can call `from_kwargs` to instantiate the response object, and to add `from_kwargs` as a class method on all response dataclasses.

Looking at our `Client` code and usages of `_get`, `_post`, and `_put`, we see that it is really only `_get` that tries to hydrate specific response dataclasses. Endpoints that use `_put` and `_post` all pass in `dict` as the response class to hydrate.

So it is a sufficient fix to only change `Client._get`.